### PR TITLE
Fix KTS generation

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -29,7 +29,7 @@ repositories {
 }
 
 application {
-    mainClass.set("com.android.gradle.structure.generator.Main")
+    mainClass.set("com.android.gradle.replicator.generator.Main")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/generator/src/main/kotlin/com/android/gradle/replicator/generator/Main.kt
+++ b/generator/src/main/kotlin/com/android/gradle/replicator/generator/Main.kt
@@ -106,7 +106,7 @@ class Main {
                 -f, --filter-libraries: a file containing a list of libraries to filter or replace
                                         Format for removal is one line per maven coordinates to remove
                                         To replace a library, add " -> <coordinate to replace with>"
-                -d, --add-libraries: a file containing libraries to add to specific sub-projects. Line format is:
+                -a, --add-libraries: a file containing libraries to add to specific sub-projects. Line format is:
                                      <modulepath><space><configuration name><space><dependency string>
                 --kts: generates kts-based build files
 """.trimIndent()

--- a/generator/src/main/kotlin/com/android/gradle/replicator/generator/writer/KtsWriter.kt
+++ b/generator/src/main/kotlin/com/android/gradle/replicator/generator/writer/KtsWriter.kt
@@ -28,7 +28,7 @@ class KtsWriter(
         writeIndent()
         buffer.append("""id("$pluginId")""")
         version?.let {
-            buffer.append(" version '$version'")
+            buffer.append(" version \"$version\"")
         }
         if (!apply) {
             buffer.append(" apply false")

--- a/generator/src/test/kotlin/com/android/gradle/replicator/generator/BasicAndroidTest.kt
+++ b/generator/src/test/kotlin/com/android/gradle/replicator/generator/BasicAndroidTest.kt
@@ -80,8 +80,6 @@ class BasicAndroidTest: BaseTest() {
                     |    classpath("com.android.tools.build:gradle:4.0.1")
                     |  }
                     |}
-                    |plugins {
-                    |}
                     |allprojects {
                     |  repositories {
                     |    google()
@@ -104,8 +102,6 @@ class BasicAndroidTest: BaseTest() {
                     |  dependencies {
                     |    classpath 'com.android.tools.build:gradle:4.0.1'
                     |  }
-                    |}
-                    |plugins {
                     |}
                     |allprojects {
                     |  repositories {

--- a/generator/src/test/kotlin/com/android/gradle/replicator/generator/BasicKotlinTest.kt
+++ b/generator/src/test/kotlin/com/android/gradle/replicator/generator/BasicKotlinTest.kt
@@ -26,13 +26,13 @@ import org.junit.runners.Parameterized
 import java.io.File
 
 @RunWith(Parameterized::class)
-class BasicAndroidWithKotlinTest: BaseTest() {
+class BasicKotlinTest: BaseTest() {
 
     companion object {
         private const val TEST_STRUCTURE: String = """
 {
   "gradle": "6.1.1",
-  "agp": "4.0.1",
+  "agp": "n/a",
   "kotlin": "1.3.72",
   "properties": [],
   "rootModule": {
@@ -44,19 +44,12 @@ class BasicAndroidWithKotlinTest: BaseTest() {
     {
       "path": ":module1",
       "plugins": [
-        "kotlin-android",
-        "com.android.application"
+        "org.jetbrains.kotlin.jvm"
       ],
       "javaSources": {
         "fileCount": 1
       },
-      "dependencies": [],
-      "android": {
-        "compileSdkVersion": "android-30",
-        "minSdkVersion": 21,
-        "targetSdkVersion": 30,
-        "buildFeatures": {}
-      }
+      "dependencies": []
     }
   ]
 }
@@ -72,15 +65,8 @@ class BasicAndroidWithKotlinTest: BaseTest() {
         Truth.assertWithMessage(rootBuildFile.absolutePath).that(rootBuildFile.readText()).isEqualTo(
             select(
                 kts = """
-                    |buildscript {
-                    |  repositories {
-                    |    google()
-                    |    jcenter()
-                    |  }
-                    |  dependencies {
-                    |    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
-                    |    classpath("com.android.tools.build:gradle:4.0.1")
-                    |  }
+                    |plugins {
+                    |  id("org.jetbrains.kotlin.jvm") version "1.3.72" apply false
                     |}
                     |allprojects {
                     |  repositories {
@@ -96,15 +82,8 @@ class BasicAndroidWithKotlinTest: BaseTest() {
                     |
                 """.trimMargin(),
                 groovy = """
-                    |buildscript {
-                    |  repositories {
-                    |    google()
-                    |    jcenter()
-                    |  }
-                    |  dependencies {
-                    |    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72'
-                    |    classpath 'com.android.tools.build:gradle:4.0.1'
-                    |  }
+                    |plugins {
+                    |  id 'org.jetbrains.kotlin.jvm' version '1.3.72' apply false
                     |}
                     |allprojects {
                     |  repositories {
@@ -142,22 +121,7 @@ class BasicAndroidWithKotlinTest: BaseTest() {
             select(
                 kts = """
                     |plugins {
-                    |  id("com.android.application")
-                    |  id("kotlin-android")
-                    |}
-                    |android {
-                    |  compileSdkVersion = "android-30"
-                    |  defaultConfig {
-                    |    minSdkVersion(21)
-                    |    targetSdkVersion(30)
-                    |  }
-                    |  compileOptions {
-                    |    sourceCompatibility = JavaVersion.VERSION_1_8
-                    |    targetCompatibility = JavaVersion.VERSION_1_8
-                    |  }
-                    |  kotlinOptions {
-                    |    jvmTarget = "1.8"
-                    |  }
+                    |  id("org.jetbrains.kotlin.jvm")
                     |}
                     |dependencies {
                     |}
@@ -165,22 +129,7 @@ class BasicAndroidWithKotlinTest: BaseTest() {
                 """.trimMargin(),
                 groovy = """
                     |plugins {
-                    |  id 'com.android.application'
-                    |  id 'kotlin-android'
-                    |}
-                    |android {
-                    |  compileSdkVersion = 'android-30'
-                    |  defaultConfig {
-                    |    minSdkVersion 21
-                    |    targetSdkVersion 30
-                    |  }
-                    |  compileOptions {
-                    |    sourceCompatibility = JavaVersion.VERSION_1_8
-                    |    targetCompatibility = JavaVersion.VERSION_1_8
-                    |  }
-                    |  kotlinOptions {
-                    |    jvmTarget = '1.8'
-                    |  }
+                    |  id 'org.jetbrains.kotlin.jvm'
                     |}
                     |dependencies {
                     |}

--- a/model/src/main/kotlin/com/android/gradle/replicator/model/PluginType.kt
+++ b/model/src/main/kotlin/com/android/gradle/replicator/model/PluginType.kt
@@ -25,6 +25,7 @@ enum class PluginType(
     val isKotlin: Boolean = false,
     val isJava: Boolean = false,
     val useNewDsl: Boolean = true,
+    val requireVersions: Boolean = false,
     val priority: Int = 0
 ) {
     JAVA_LIBRARY(
@@ -37,45 +38,53 @@ enum class PluginType(
     ),
     APPLICATION(
         id = "application",
-        isJava = true
+        isJava = true,
+        requireVersions = true
     ),
     KOTLIN_JVM(
         id = "org.jetbrains.kotlin.jvm",
         oldId = "kotlin",
         kotlinId = "jvm",
-        isKotlin = true
+        isKotlin = true,
+        requireVersions = true
     ),
     KOTLIN_ANDROID(
         id = "kotlin-android",
         isAndroid = true,
         isKotlin = true,
         useNewDsl = false,
+        requireVersions = true,
         priority = 10
     ),
     KAPT(
         id = "kotlin-kapt",
         isKotlin = true,
         useNewDsl = false,
+        requireVersions = true,
         priority = 11
     ),
     ANDROID_APP(
         id = "com.android.application",
         isAndroid = true,
-        useNewDsl = false
+        useNewDsl = false,
+        requireVersions = true
     ),
     ANDROID_LIB(
         id = "com.android.library",
         isAndroid = true,
-        useNewDsl = false
+        useNewDsl = false,
+        requireVersions = true
     ),
     ANDROID_TEST(
         id = "com.android.test",
         isAndroid = true,
-        useNewDsl = false
+        useNewDsl = false,
+        requireVersions = true
     ),
     ANDROID_DYNAMIC_FEATURE(
         id = "com.android.dynamic-feature",
         isAndroid = true,
-        useNewDsl = false
+        useNewDsl = false,
+        requireVersions = true
     ),
 }


### PR DESCRIPTION
Plugin version in new plugin block used the wrong string quote
character in KTS (' instead of "). This was due to a lack for tests,
so this change also adds new tests with pure java-library and pure
kotlin projects.

This change also does a bit of clean-up to avoid creating the
buildscript and plugins blocks in the root project if they are
not needed.