### PR TITLE
Add resource data gathering to project replicator plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,10 @@ jobs:
       # Runs a single command using the runners shell
       - name: run checks
         run: ./gradlew check --stacktrace
+
+      - name: Archive test logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: gradle-test-logs
+          path: **/build/reports/tests
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Archive test logs
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: gradle-test-logs
-          path: **/build/reports/tests
+          path: ./**/build/reports/tests
         

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/Main.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/Main.kt
@@ -116,7 +116,8 @@ class Main {
             outputFolder: File) {
         val generator = generatorType.initialize(parameters)
         repeat(numberOfSources) { count ->
-            val className = "Class" + ('A'+ count/(26*26)) + ('A'+ (count/26)%26) + ('A'+ count%26)
+            val suffix = if (generatorType == GeneratorType.Java) "Java" else ""
+            val className = "Class" + ('A'+ count/(26*26)) + ('A'+ (count/26)%26) + ('A'+ count%26) + suffix
             val sourceFolder = File(outputFolder, "com/android/example/$moduleName")
             sourceFolder.mkdirs()
             val outputFile = File(sourceFolder, generatorType.classNameToSourceFileName(className))

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/SingleClassGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/SingleClassGenerator.kt
@@ -132,7 +132,9 @@ class SingleClassGenerator(
                 classGenerator.allocateValue(random, false, allocatableType)
         )
         classGenerator.indent()
-        addMethodCall(variableName, allocatableType.callableMethods.random(random))
+        if (allocatableType.callableMethods.isNotEmpty()) {
+            addMethodCall(variableName, allocatableType.callableMethods.random(random))
+        }
         classGenerator.println()
     }
 

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/parsing/ArgsParser.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/parsing/ArgsParser.kt
@@ -123,6 +123,7 @@ class ArgsParser {
                 arg.value?.toString()?.split(",")?.let {
                     currentOption.argv.addAll(it)
                 }
+                currentOption.isPresent = true
             }
         }
         // Post-parse sanity check

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/parsing/ArgsParser.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/parsing/ArgsParser.kt
@@ -127,7 +127,7 @@ class ArgsParser {
         }
         // Post-parse sanity check
         argsFileOpts.forEach { opt ->
-            if (opt.value.isPresent && opt.value.argv.size != UNLIMITED_ARGC && opt.value.argv.size != opt.value.argc) {
+            if (opt.value.isPresent && opt.value.argc != UNLIMITED_ARGC && opt.value.argv.size != opt.value.argc) {
                 throw java.lang.IllegalArgumentException("wrong # of args for ${opt.key}. Expected ${opt.value.argc} but got ${opt.value.argv.size}")
             }
         }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/DrawableResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/DrawableResourceGenerator.kt
@@ -17,12 +17,7 @@
 package com.android.gradle.replicator.resgen
 
 import com.android.gradle.replicator.resgen.util.FileTypes
-import com.android.gradle.replicator.resgen.util.MAX_VECTOR_IMAGE_LINES_LARGE
-import com.android.gradle.replicator.resgen.util.MAX_VECTOR_IMAGE_LINES_MEDIUM
-import com.android.gradle.replicator.resgen.util.MAX_VECTOR_IMAGE_LINES_SMALL
-import com.android.gradle.replicator.resgen.util.MAX_VECTOR_IMAGE_SIZE_LARGE
-import com.android.gradle.replicator.resgen.util.MAX_VECTOR_IMAGE_SIZE_MEDIUM
-import com.android.gradle.replicator.resgen.util.MAX_VECTOR_IMAGE_SIZE_SMALL
+import com.android.gradle.replicator.resgen.util.ResgenConstants
 import com.android.gradle.replicator.resgen.util.VectorDrawableGenerator
 import com.android.gradle.replicator.resgen.util.copyResourceFile
 import com.android.gradle.replicator.resgen.util.genFileNameCharacters
@@ -30,11 +25,9 @@ import com.android.gradle.replicator.resgen.util.getFileType
 import com.android.gradle.replicator.resgen.util.getRandomResource
 import com.google.common.annotations.VisibleForTesting
 import java.io.File
-import java.lang.RuntimeException
 import kotlin.random.Random
 
-
-class DrawableResourceGenerator (val random: Random): ResourceGenerator {
+class DrawableResourceGenerator (val random: Random, val constants: ResgenConstants): ResourceGenerator {
 
     @set:VisibleForTesting
     var numberOfResourceElements: Int?= null
@@ -96,37 +89,37 @@ class DrawableResourceGenerator (val random: Random): ResourceGenerator {
 
         qualifiers.forEach {
             when (it) {
-                "ldpi" -> return MAX_VECTOR_IMAGE_LINES_SMALL
+                "ldpi" -> return constants.vectorImage.MAX_VECTOR_IMAGE_LINES_SMALL
                 "nodpi",
                 "anydpi",
                 "tvdpi",
-                "mdpi"-> return MAX_VECTOR_IMAGE_LINES_MEDIUM
+                "mdpi"-> return constants.vectorImage.MAX_VECTOR_IMAGE_LINES_MEDIUM
                 "hdpi",
                 "xhdpi",
                 "xxhdpi",
-                "xxxhdpi" -> return MAX_VECTOR_IMAGE_LINES_LARGE
+                "xxxhdpi" -> return constants.vectorImage.MAX_VECTOR_IMAGE_LINES_LARGE
                 else -> {}
             }
         }
-        return MAX_VECTOR_IMAGE_SIZE_MEDIUM // NNNDPI also ends up here
+        return constants.vectorImage.MAX_VECTOR_IMAGE_SIZE_MEDIUM // NNNDPI also ends up here
     }
 
     private fun selectMaxImageSize(qualifiers: List<String>): Int {
         qualifiers.forEach {
             when (it) {
-                "ldpi" -> return MAX_VECTOR_IMAGE_SIZE_SMALL
+                "ldpi" -> return constants.vectorImage.MAX_VECTOR_IMAGE_SIZE_SMALL
                 "nodpi",
                 "anydpi",
                 "tvdpi",
-                "mdpi"-> return MAX_VECTOR_IMAGE_SIZE_MEDIUM
+                "mdpi"-> return constants.vectorImage.MAX_VECTOR_IMAGE_SIZE_MEDIUM
                 "hdpi",
                 "xhdpi",
                 "xxhdpi",
-                "xxxhdpi" -> return MAX_VECTOR_IMAGE_SIZE_LARGE
+                "xxxhdpi" -> return constants.vectorImage.MAX_VECTOR_IMAGE_SIZE_LARGE
                 else -> {}
             }
         }
-        return MAX_VECTOR_IMAGE_SIZE_MEDIUM // NNNDPI also ends up here
+        return constants.vectorImage.MAX_VECTOR_IMAGE_SIZE_MEDIUM // NNNDPI also ends up here
     }
 
     private fun generateVectorDrawableResource(

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/GeneratorDriver.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/GeneratorDriver.kt
@@ -1,32 +1,38 @@
 package com.android.gradle.replicator.resgen
 
 import com.android.gradle.replicator.model.internal.resources.AbstractAndroidResourceProperties
+import com.android.gradle.replicator.resgen.util.ResgenConstants
 import java.io.File
 import kotlin.random.Random
 
 class GeneratorDriver (val random: Random) {
     // TODO: implement other generators
-    private fun getGenerator(random: Random, resourceType: String): ResourceGenerator? {
+    private fun getGenerator(random: Random, resourceType: String, constants: ResgenConstants): ResourceGenerator? {
         return when(resourceType) {
             //"animator" ->
             //"anim" ->
             //"color" ->
-            "drawable" -> DrawableResourceGenerator(random)
+            "drawable" -> DrawableResourceGenerator(random, constants)
             "font" -> FontResourceGenerator(random)
             //"layout" ->
             //"menu" ->
-            "mipmap" -> DrawableResourceGenerator(random)
+            "mipmap" -> DrawableResourceGenerator(random, constants)
             "raw" -> RawResourceGenerator(random)
             //"transition" ->
-            "values" -> ValueResourceGenerator(random)
+            "values" -> ValueResourceGenerator(random, constants)
             //"xml" ->
             else -> null
         }
     }
 
-    fun generateResources(outputFolder: File, resourceType: String, resourceProperties: AbstractAndroidResourceProperties) {
+    fun generateResources(
+        outputFolder: File,
+        resourceType: String,
+        resourceProperties: AbstractAndroidResourceProperties,
+        resgenConstants: ResgenConstants) {
+
         // TODO: Separate resource properties by type
-        val generator = getGenerator(random, resourceType)
+        val generator = getGenerator(random, resourceType, resgenConstants)
 
         // empty qualifiers means the folder is unqualified, as in "mipmap" instead of "mipmap-hidpi"
         val qualifiedFolder =

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/GeneratorDriver.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/GeneratorDriver.kt
@@ -1,5 +1,6 @@
 package com.android.gradle.replicator.resgen
 
+import com.android.gradle.replicator.model.internal.resources.AbstractAndroidResourceProperties
 import java.io.File
 import kotlin.random.Random
 
@@ -23,7 +24,8 @@ class GeneratorDriver (val random: Random) {
         }
     }
 
-    fun generateResources(outputFolder: File, resourceType: String, resourceProperties: AndroidResourceProperties) {
+    fun generateResources(outputFolder: File, resourceType: String, resourceProperties: AbstractAndroidResourceProperties) {
+        // TODO: Separate resource properties by type
         val generator = getGenerator(random, resourceType)
 
         // empty qualifiers means the folder is unqualified, as in "mipmap" instead of "mipmap-hidpi"

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/Main.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/Main.kt
@@ -21,6 +21,7 @@ import com.android.gradle.replicator.model.SourceFilesInfo
 import com.android.gradle.replicator.model.internal.*
 import com.android.gradle.replicator.model.internal.resources.AndroidResourceMap
 import com.android.gradle.replicator.parsing.ArgsParser
+import com.android.gradle.replicator.resgen.util.ResgenConstants
 import com.google.gson.stream.JsonReader
 import java.io.File
 import java.io.FileNotFoundException
@@ -50,6 +51,7 @@ class Main {
         val androidOutputFolderOption = parser.option(longName = "androidOutput", shortName = "ao", argc = 1)
         val javaOutputFolderOption = parser.option(longName = "javaOutput", shortName = "jo", argc = 1)
         val resJsonOption = parser.option(longName = "resJson", shortName = "rj", argc = 1)
+        val resgenConstantsFile = parser.option(longName = "generationProperties", shortName = "gp", argc = 1)
         val seedOption = parser.option(longName = "seed", shortName = "s", argc = 1)
 
         parser.parseArgs(args)
@@ -82,11 +84,14 @@ class Main {
 
         val arguments = argumentsBuilder.build()
 
+        val resgenConstants = ResgenConstants(resgenConstantsFile.orNull?.first?.let { File(it) })
+
         if (countResources(arguments.androidResourcesMap) > 0) {
             generateAndroidResources(
                     arguments.androidResourcesMap,
                     arguments,
-                    androidOutputFolder
+                    androidOutputFolder,
+                    resgenConstants
             )
         }
         if (arguments.numberOfJavaResources > 0) {
@@ -101,12 +106,13 @@ class Main {
     private fun generateAndroidResources(
             resMap: AndroidResourceMap,
             parameters: ResourceGenerationParameters,
-            outputFolder: File) {
+            outputFolder: File,
+            resgenConstants: ResgenConstants) {
         resMap.forEach { resourceType ->
             val random = Random(parameters.seed)
             val generator = GeneratorDriver(random)
             resourceType.value.forEach { resourceProperties ->
-                generator.generateResources(outputFolder, resourceType.key, resourceProperties)
+                generator.generateResources(outputFolder, resourceType.key, resourceProperties, resgenConstants)
             }
         }
     }
@@ -115,8 +121,7 @@ class Main {
             numberOfResources: Int,
             parameters: ResourceGenerationParameters,
             outputFolder: File) {
-        repeat(numberOfResources) { count ->
-        }
+        // To be implemented
         return
     }
 
@@ -159,5 +164,6 @@ class Main {
         println("\t-rj/--resJson : classpath for all private (implementation) libraries, each element is a .jar file")
         println("\t-ao/--androidOutput : android resources output folder")
         println("\t-jo/--javaOutput : java resources output folder")
+        println("\t-gp/--generationProperties : resource generation properties file")
     }
 }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ResourceGenerationParameters.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ResourceGenerationParameters.kt
@@ -16,9 +16,7 @@
  */
 package com.android.gradle.replicator.resgen
 
-data class AndroidResourceProperties (val qualifiers: String, val extension: String, val quantity: Int)
-
-typealias AndroidResourceMap = Map<String, List<AndroidResourceProperties>>
+import com.android.gradle.replicator.model.internal.resources.AndroidResourceMap
 
 /**
  * Parameters for the generation for a module.
@@ -41,7 +39,7 @@ data class ResourceGenerationParameters(
 ) {
     class Builder {
         private var seed = 1
-        private var nbOfAndroidResources: AndroidResourceMap = mapOf()
+        private var nbOfAndroidResources: AndroidResourceMap = mutableMapOf()
         private var nbOfJavaResources = 0
 
         fun setSeed(seed: Int) { this.seed = seed }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ValueResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ValueResourceGenerator.kt
@@ -16,12 +16,7 @@
  */
 package com.android.gradle.replicator.resgen
 
-import com.android.gradle.replicator.resgen.util.DIMENSION_UNITS
-import com.android.gradle.replicator.resgen.util.MAX_ARRAY_ELEMENTS
-import com.android.gradle.replicator.resgen.util.MAX_DIMENSION
-import com.android.gradle.replicator.resgen.util.MAX_STRING_WORD_COUNT
-import com.android.gradle.replicator.resgen.util.MAX_VALUES
-import com.android.gradle.replicator.resgen.util.POSSIBLE_COLOR_DIGITS
+import com.android.gradle.replicator.resgen.util.ResgenConstants
 import com.android.gradle.replicator.resgen.util.genFileNameCharacters
 import com.android.gradle.replicator.resgen.util.genHex
 import com.android.gradle.replicator.resgen.util.genName
@@ -30,7 +25,7 @@ import com.google.common.annotations.VisibleForTesting
 import java.io.File
 import kotlin.random.Random
 
-class ValueResourceGenerator (val random: Random): ResourceGenerator {
+class ValueResourceGenerator (val random: Random, val constants: ResgenConstants): ResourceGenerator {
 
     @set:VisibleForTesting
     var numberOfResourceElements: Int?= null
@@ -75,7 +70,7 @@ class ValueResourceGenerator (val random: Random): ResourceGenerator {
     private fun generateXmlValueResource (
             outputFile: File
     ) {
-        val numberOfValues = numberOfResourceElements ?: random.nextInt(1, MAX_VALUES)
+        val numberOfValues = numberOfResourceElements ?: random.nextInt(1, constants.values.MAX_VALUES)
         val allValueTypes = ValueType.values()
 
         val xmlLines = mutableListOf<String>()
@@ -111,9 +106,9 @@ class ValueResourceGenerator (val random: Random): ResourceGenerator {
     private fun stringBlock (): String {
         val name = genName(random)
         val value = genString(
-                MAX_STRING_WORD_COUNT,
-                separator = " ",
-                random = random)
+            constants.values.MAX_STRING_WORD_COUNT,
+            separator = " ",
+            random = random)
         return "    <string name=\"$name\">$value</string>"
     }
 
@@ -137,7 +132,7 @@ class ValueResourceGenerator (val random: Random): ResourceGenerator {
          * #RRGGBB
          * #AARRGGBB
          */
-        val numberOfDigits = POSSIBLE_COLOR_DIGITS.random(random)
+        val numberOfDigits = constants.values.POSSIBLE_COLOR_DIGITS.random(random)
 
         val value = genHex(numberOfDigits, random)
 
@@ -146,7 +141,7 @@ class ValueResourceGenerator (val random: Random): ResourceGenerator {
 
     private fun dimenBlock (): String {
         val name = genName(random)
-        val value = "${random.nextInt(MAX_DIMENSION)}${DIMENSION_UNITS.random(random)}"
+        val value = "${random.nextInt(constants.values.MAX_DIMENSION)}${constants.values.DIMENSION_UNITS.random(random)}"
 
         return "    <dimen name=\"$name\">$value</dimen>"
     }
@@ -158,7 +153,7 @@ class ValueResourceGenerator (val random: Random): ResourceGenerator {
 
     private fun intArrayBlock (): List<String> {
         val name = genName(random)
-        val size = random.nextInt(MAX_ARRAY_ELEMENTS)
+        val size = random.nextInt(constants.values.MAX_ARRAY_ELEMENTS)
         val result = mutableListOf("    <integer-array name=\"$name\">")
 
         repeat(size) {

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/ResgenConstants.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/ResgenConstants.kt
@@ -1,18 +1,67 @@
 package com.android.gradle.replicator.resgen.util
 
-// Vector image
-const val MAX_VECTOR_IMAGE_SIZE_SMALL = 100
-const val MAX_VECTOR_IMAGE_SIZE_MEDIUM = 150
-const val MAX_VECTOR_IMAGE_SIZE_LARGE = 200
-const val MAX_VECTOR_IMAGE_LINES_SMALL = 50
-const val MAX_VECTOR_IMAGE_LINES_MEDIUM = 75
-const val MAX_VECTOR_IMAGE_LINES_LARGE = 100
+import com.android.gradle.replicator.parsing.ArgsParser
+import java.io.File
 
-// Values
+class ResgenConstants (propertyFile: File? = null) {
+    data class VectorImageConstants (
+        val MAX_VECTOR_IMAGE_SIZE_SMALL: Int,
+        val MAX_VECTOR_IMAGE_SIZE_MEDIUM: Int,
+        val MAX_VECTOR_IMAGE_SIZE_LARGE: Int,
+        val MAX_VECTOR_IMAGE_LINES_SMALL: Int,
+        val MAX_VECTOR_IMAGE_LINES_MEDIUM: Int,
+        val MAX_VECTOR_IMAGE_LINES_LARGE: Int)
 
-const val MAX_VALUES = 21
-const val MAX_ARRAY_ELEMENTS = 20
-const val MAX_STRING_WORD_COUNT = 20
-const val MAX_DIMENSION = 2048
-val POSSIBLE_COLOR_DIGITS = listOf(3, 4, 6, 8)
-val DIMENSION_UNITS = listOf("dp", "sp", "pt", "px", "mm", "in")
+    data class ValuesConstants (
+        val MAX_VALUES: Int,
+        val MAX_ARRAY_ELEMENTS: Int,
+        val MAX_STRING_WORD_COUNT: Int,
+        val MAX_DIMENSION: Int) {
+        val POSSIBLE_COLOR_DIGITS: List<Int> = listOf(3, 4, 6, 8)
+        val DIMENSION_UNITS: List<String> = listOf("dp", "sp", "pt", "px", "mm", "in")
+    }
+
+    val vectorImage: VectorImageConstants
+    val values: ValuesConstants
+
+    init {
+        val parser = ArgsParser()
+
+        // Vector drawables
+        val maxVectorImageSizeSmall =  parser.option(propertyName = "maxVectorImageSizeSmall", argc = 1)
+        val maxVectorImageSizeMedium =  parser.option(propertyName = "maxVectorImageSizeMedium", argc = 1)
+        val maxVectorImageSizeLarge =  parser.option(propertyName = "maxVectorImageSizeLarge", argc = 1)
+        val maxVectorImageLinesSmall =  parser.option(propertyName = "maxVectorImageLinesSmall", argc = 1)
+        val maxVectorImageLinesMedium =  parser.option(propertyName = "maxVectorImageLinesMedium", argc = 1)
+        val maxVectorImageLinesLarge =  parser.option(propertyName = "maxVectorImageLinesLarge", argc = 1)
+
+        // Values
+        val maxValues =  parser.option(propertyName = "maxValues", argc = 1)
+        val maxArrayElements =  parser.option(propertyName = "maxArrayElements", argc = 1)
+        val maxStringWordCount =  parser.option(propertyName = "maxStringWordCount", argc = 1)
+        val maxDimension =  parser.option(propertyName = "maxDimension", argc = 1)
+
+        // Use default values if no property file exists
+        propertyFile?.let {
+            parser.parsePropertyFile(it)
+        }
+
+        // random(1, 2) is the same as requesting only the number 1, so to get the REAL max we need to add 1
+        vectorImage = VectorImageConstants(
+            MAX_VECTOR_IMAGE_SIZE_SMALL = (maxVectorImageSizeSmall.orNull?.first?.toInt() ?: 100) + 1,
+            MAX_VECTOR_IMAGE_SIZE_MEDIUM = (maxVectorImageSizeMedium.orNull?.first?.toInt() ?: 150) + 1,
+            MAX_VECTOR_IMAGE_SIZE_LARGE = (maxVectorImageSizeLarge.orNull?.first?.toInt() ?: 200) + 1,
+            MAX_VECTOR_IMAGE_LINES_SMALL = (maxVectorImageLinesSmall.orNull?.first?.toInt() ?: 50) + 1,
+            MAX_VECTOR_IMAGE_LINES_MEDIUM = (maxVectorImageLinesMedium.orNull?.first?.toInt() ?: 75) + 1,
+            MAX_VECTOR_IMAGE_LINES_LARGE = (maxVectorImageLinesLarge.orNull?.first?.toInt() ?: 100) + 1
+        )
+
+        // same as above
+        values = ValuesConstants(
+            MAX_VALUES = (maxValues.orNull?.first?.toInt() ?: 21) + 1,
+            MAX_ARRAY_ELEMENTS = (maxArrayElements.orNull?.first?.toInt() ?: 20) + 1,
+            MAX_STRING_WORD_COUNT = (maxStringWordCount.orNull?.first?.toInt() ?: 20) + 1,
+            MAX_DIMENSION = (maxDimension.orNull?.first?.toInt() ?: 2048) + 1
+        )
+    }
+}

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/VectorDrawableGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/VectorDrawableGenerator.kt
@@ -5,8 +5,8 @@ import kotlin.random.Random
 class VectorDrawableGenerator (val random: Random) {
     fun generateImage(numberOfPathVectors: Int, maxVectorImageSize: Int): List<String> {
         val lines = mutableListOf<String>()
-        val width = random.nextInt(maxVectorImageSize)
-        val height = random.nextInt(maxVectorImageSize)
+        val width = random.nextInt(1, maxVectorImageSize)
+        val height = random.nextInt(1, maxVectorImageSize)
         val viewportWidth = random.nextInt(width)
         val viewportHeight = random.nextInt(height)
         val hasBackground = random.nextBoolean()

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/AbstractResourceGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/AbstractResourceGenerationUnitTest.kt
@@ -17,10 +17,8 @@
 
 package com.android.gradle.replicator.resgen
 
-import com.google.common.truth.Truth
 import org.junit.Before
 import org.junit.Rule
-import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
@@ -115,90 +115,90 @@ class DrawableGenerationUnitTest: AbstractResourceGenerationUnitTest() {
         val expectedXmlAAA = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
-                android:width="12dp"
-                android:height="13dp"
-                android:viewportWidth="2"
-                android:viewportHeight="2">
+                android:width="13dp"
+                android:height="14dp"
+                android:viewportWidth="1"
+                android:viewportHeight="1">
                 <path
                     android:fillColor="#00010203"
-                    android:pathData="M0,0h12v13h-12z" />
+                    android:pathData="M0,0h13v14h-13z" />
                 <path
                     android:fillColor="#04050607"
                     android:strokeColor="#08090a0b"
                     android:strokeWidth="0.02"
                     android:fillAlpha="0.021"
-                    android:pathData="M4,4L6,6" />
+                    android:pathData="M3,3L5,5" />
                 <path
                     android:fillColor="#0c0d0e0f"
                     android:strokeColor="#10111213"
                     android:strokeWidth="0.026"
                     android:fillAlpha="0.027"
-                    android:pathData="M10,10L0,12" />
+                    android:pathData="M9,9L11,11" />
                 <path
                     android:fillColor="#14151617"
                     android:strokeColor="#18191a1b"
                     android:strokeWidth="0.032"
                     android:fillAlpha="0.033"
-                    android:pathData="M4,3L6,5" />
+                    android:pathData="M2,1L4,3" />
             </vector>
         """.trimIndent()
 
         val expectedXmlAAB = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
-                android:width="34dp"
-                android:height="35dp"
-                android:viewportWidth="2"
-                android:viewportHeight="2">
+                android:width="35dp"
+                android:height="36dp"
+                android:viewportWidth="1"
+                android:viewportHeight="1">
                 <path
                     android:fillColor="#1c1d1e1f"
                     android:strokeColor="#20212223"
                     android:strokeWidth="0.042"
                     android:fillAlpha="0.043"
-                    android:pathData="M4,4L6,6" />
+                    android:pathData="M3,3L5,5" />
                 <path
                     android:fillColor="#24252627"
                     android:strokeColor="#28292a2b"
                     android:strokeWidth="0.048"
                     android:fillAlpha="0.049"
-                    android:pathData="M10,10L12,12" />
+                    android:pathData="M9,9L11,11" />
                 <path
                     android:fillColor="#2c2d2e2f"
                     android:strokeColor="#30313233"
                     android:strokeWidth="0.054"
                     android:fillAlpha="0.055"
-                    android:pathData="M16,16L18,18" />
+                    android:pathData="M15,15L17,17" />
             </vector>
         """.trimIndent()
 
         val expectedXmlAAC = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
-                android:width="56dp"
-                android:height="57dp"
-                android:viewportWidth="2"
-                android:viewportHeight="2">
+                android:width="57dp"
+                android:height="58dp"
+                android:viewportWidth="1"
+                android:viewportHeight="1">
                 <path
                     android:fillColor="#34353637"
-                    android:pathData="M0,0h56v57h-56z" />
+                    android:pathData="M0,0h57v58h-57z" />
                 <path
                     android:fillColor="#38393a3b"
                     android:strokeColor="#3c3d3e3f"
                     android:strokeWidth="0.064"
                     android:fillAlpha="0.065"
-                    android:pathData="M4,4L6,6" />
+                    android:pathData="M3,3L5,5" />
                 <path
                     android:fillColor="#40414243"
                     android:strokeColor="#44454647"
                     android:strokeWidth="0.07"
                     android:fillAlpha="0.071"
-                    android:pathData="M10,10L12,12" />
+                    android:pathData="M9,9L11,11" />
                 <path
                     android:fillColor="#48494a4b"
                     android:strokeColor="#4c4d4e4f"
                     android:strokeWidth="0.076"
                     android:fillAlpha="0.077"
-                    android:pathData="M16,16L18,18" />
+                    android:pathData="M15,15L17,17" />
             </vector>
         """.trimIndent()
 

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
@@ -1,13 +1,15 @@
 package com.android.gradle.replicator.resgen
 
+import com.android.gradle.replicator.resgen.util.ResgenConstants
 import com.google.common.truth.Truth
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 import java.io.File
 
 class DrawableGenerationUnitTest: AbstractResourceGenerationUnitTest() {
     @Test
     fun testDrawableGeneration() {
-        val generator = DrawableResourceGenerator(random)
+        val generator = DrawableResourceGenerator(random, ResgenConstants())
         generator.numberOfResourceElements = 3
 
         val pngFolder = output.newFolder("png")
@@ -112,6 +114,7 @@ class DrawableGenerationUnitTest: AbstractResourceGenerationUnitTest() {
             Truth.assertThat(File(it.value.first, it.key).readBytes()).isEqualTo(it.value.second.readBytes())
         }
 
+        @Language("xml")
         val expectedXmlAAA = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -143,6 +146,7 @@ class DrawableGenerationUnitTest: AbstractResourceGenerationUnitTest() {
             </vector>
         """.trimIndent()
 
+        @Language("xml")
         val expectedXmlAAB = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -171,6 +175,7 @@ class DrawableGenerationUnitTest: AbstractResourceGenerationUnitTest() {
             </vector>
         """.trimIndent()
 
+        @Language("xml")
         val expectedXmlAAC = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ResgenConstantsUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ResgenConstantsUnitTest.kt
@@ -1,0 +1,68 @@
+package com.android.gradle.replicator.resgen
+
+import com.android.gradle.replicator.resgen.util.ResgenConstants
+import com.google.common.truth.Truth.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ResgenConstantsUnitTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun testPropertyFileLoadsProperly() {
+        @Language("properties")
+        val propertiesText = """
+            # Vector image generation
+            maxVectorImageSizeSmall=1
+            maxVectorImageSizeMedium=2
+            maxVectorImageSizeLarge=3
+            maxVectorImageLinesSmall=4
+            maxVectorImageLinesMedium=5
+            maxVectorImageLinesLarge=6
+
+            # Values generation
+            maxValues=7
+            maxArrayElements=8
+            maxStringWordCount=9
+            maxDimension=10""".trimIndent()
+
+        val propertiesFile = temporaryFolder.newFile("constants.properties")
+        propertiesFile.writeText(propertiesText)
+
+        val resgenConstants = ResgenConstants(propertiesFile)
+
+        // Actual constants are 1 larger because of how random(from, to) works
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_SMALL).isEqualTo(2)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_MEDIUM).isEqualTo(3)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_LARGE).isEqualTo(4)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_SMALL).isEqualTo(5)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_MEDIUM).isEqualTo(6)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_LARGE).isEqualTo(7)
+
+        assertThat(resgenConstants.values.MAX_VALUES).isEqualTo(8)
+        assertThat(resgenConstants.values.MAX_ARRAY_ELEMENTS).isEqualTo(9)
+        assertThat(resgenConstants.values.MAX_STRING_WORD_COUNT).isEqualTo(10)
+        assertThat(resgenConstants.values.MAX_DIMENSION).isEqualTo(11)
+    }
+
+    @Test
+    fun testNoFileLoad() {
+        val resgenConstants = ResgenConstants()
+
+        // Actual constants are 1 larger because of how random(from, to) works
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_SMALL).isEqualTo(101)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_MEDIUM).isEqualTo(151)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_LARGE).isEqualTo(201)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_SMALL).isEqualTo(51)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_MEDIUM).isEqualTo(76)
+        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_LARGE).isEqualTo(101)
+
+        assertThat(resgenConstants.values.MAX_VALUES).isEqualTo(22)
+        assertThat(resgenConstants.values.MAX_ARRAY_ELEMENTS).isEqualTo(21)
+        assertThat(resgenConstants.values.MAX_STRING_WORD_COUNT).isEqualTo(21)
+        assertThat(resgenConstants.values.MAX_DIMENSION).isEqualTo(2049)
+    }
+}

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ValueGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ValueGenerationUnitTest.kt
@@ -1,13 +1,15 @@
 package com.android.gradle.replicator.resgen
 
+import com.android.gradle.replicator.resgen.util.ResgenConstants
 import com.google.common.truth.Truth
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 import java.io.File
 
 class ValueGenerationUnitTest: AbstractResourceGenerationUnitTest() {
     @Test
     fun testValueGeneration() {
-        val generator = ValueResourceGenerator(random)
+        val generator = ValueResourceGenerator(random, ResgenConstants())
 
         generator.numberOfResourceElements = 5
 
@@ -21,22 +23,32 @@ class ValueGenerationUnitTest: AbstractResourceGenerationUnitTest() {
         val generatedValues1 = File(output.root, "values_aaa.xml").readText()
         val generatedValues2 = File(output.root, "values_aab.xml").readText()
 
+        @Language("xml")
         val expectedValues1 = """
             <resources>
                 <string name="cool_delivery">nice constable writer wire android</string>
                 <bool name="cookie_etc._the">true</bool>
-                <string name="chocolate_vanilla_strawberry">party cool</string>
-                <string name="nice_constable">wire android face pie cookie etc. the name max</string>
+                <string name="chocolate_vanilla_strawberry">party</string>
             </resources>""".trimIndent()
 
+        @Language("xml")
         val expectedValues2 = """
             <resources>
-                <integer-array name="vanilla">
-                    <item>42</item>
+                <string name="nice_constable">wire android face pie cookie etc. the name</string>
+                <item type="id" name="chocolate_vanilla_strawberry"/>
+                <bool name="cool_delivery">false</bool>
+                <integer-array name="constable_writer_wire">
+                    <item>52</item>
+                    <item>53</item>
+                    <item>54</item>
+                    <item>55</item>
+                    <item>56</item>
+                    <item>57</item>
+                    <item>58</item>
+                    <item>59</item>
+                    <item>60</item>
                 </integer-array>
-                <color name="delivery_awesome_nice">#000</color>
-                <integer name="android_face_pie">54</integer>
-                <string name="max">chocolate vanilla strawberry pizza party cool delivery awesome nice constable writer wire android face pie cookie etc. the name max</string>
+                <item type="id" name="pizza_party_cool"/>
             </resources>""".trimIndent()
 
         Truth.assertThat(generatedValues1).isEqualTo(expectedValues1)

--- a/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/CodegenPlugin.kt
+++ b/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/CodegenPlugin.kt
@@ -46,6 +46,7 @@ class CodegenPlugin: AbstractCodeGenPlugin() {
             task.seed.set(Random.nextInt())
             task.androidOutputDirectory.set(project.layout.projectDirectory.dir("src/res"))
             task.javaOutputDirectory.set(project.layout.projectDirectory.dir("src/resources"))
+            task.generationProperties.set(project.rootProject.layout.projectDirectory.file("generation.properties"))
         }
 
         val generateTask = project.tasks.register(

--- a/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/GenerateResources.kt
+++ b/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/GenerateResources.kt
@@ -20,7 +20,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 import kotlin.random.Random
 
 abstract class GenerateResources: DefaultTask() {
@@ -30,6 +33,9 @@ abstract class GenerateResources: DefaultTask() {
 
     @get:Input
     abstract val seed: Property<Int>
+
+    @get:InputFile
+    abstract val generationProperties: RegularFileProperty
 
     @get:OutputDirectory
     abstract val androidOutputDirectory: DirectoryProperty
@@ -46,6 +52,7 @@ abstract class GenerateResources: DefaultTask() {
                         "--resJson", parameters.get().asFile.absolutePath,
                         "--androidOutput", androidOutputDirectory.get().asFile.absolutePath,
                         "--javaOutput", javaOutputDirectory.get().asFile.absolutePath,
+                        "--generationProperties", generationProperties.get().asFile.absolutePath,
                         "--seed", randomizer.nextInt().toString()
                 )
         )

--- a/generator/src/main/kotlin/com/android/gradle/replicator/generator/project/GradleProjectGenerator.kt
+++ b/generator/src/main/kotlin/com/android/gradle/replicator/generator/project/GradleProjectGenerator.kt
@@ -36,9 +36,6 @@ import com.google.gson.stream.JsonWriter
 import java.io.File
 import java.io.FileWriter
 
-
-
-
 class GradleProjectGenerator(
     private val destinationFolder: File,
     private val libraryFilter: Map<String, String>,
@@ -223,7 +220,7 @@ class GradleProjectGenerator(
         with(JsonWriter(FileWriter(metadataFile))) {
             this.setIndent("  ")
             beginObject()
-            module.androidResources?.also {
+            module.androidResources?.let {
                 name("androidResources")
                 AndroidResourcesAdapter().write(this, it)
             }

--- a/generator/src/main/kotlin/com/android/gradle/replicator/generator/project/GradleProjectGenerator.kt
+++ b/generator/src/main/kotlin/com/android/gradle/replicator/generator/project/GradleProjectGenerator.kt
@@ -34,6 +34,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import com.google.gson.stream.JsonWriter
 import java.io.File
+import java.io.FileOutputStream
 import java.io.FileWriter
 
 class GradleProjectGenerator(
@@ -119,6 +120,9 @@ class GradleProjectGenerator(
         // create module metadata files
         generateModuleMetadata(destinationFolder, project.rootModule)
         generateModuleResourceMetadata(destinationFolder, project.rootModule)
+
+        // create generation constants file
+        generateResgenDefaultConstants(destinationFolder)
     }
 
     private fun PluginType.useNewDsl(info: ProjectInfo): Boolean {
@@ -231,6 +235,13 @@ class GradleProjectGenerator(
             endObject()
             this.flush()
         }
+    }
+
+    private fun generateResgenDefaultConstants(folder: File) {
+        val generationPropertyFile = folder.join("generation.properties")
+
+        val loader = Thread.currentThread().contextClassLoader
+        loader.getResourceAsStream("project/resourceGeneratorConstants.properties")!!.copyTo(FileOutputStream(generationPropertyFile))
     }
 
     private fun ModuleInfo.generateDependencies() {

--- a/generator/src/main/resources/project/resourceGeneratorConstants.properties
+++ b/generator/src/main/resources/project/resourceGeneratorConstants.properties
@@ -1,0 +1,13 @@
+# Vector image generation
+maxVectorImageSizeSmall=100
+maxVectorImageSizeMedium=150
+maxVectorImageSizeLarge=200
+maxVectorImageLinesSmall=50
+maxVectorImageLinesMedium=75
+maxVectorImageLinesLarge=100
+
+# Values generation
+maxValues=21
+maxArrayElements=20
+maxStringWordCount=20
+maxDimension=2048

--- a/generator/src/test/kotlin/com/android/gradle/replicator/generator/BasicAndroidWithResourcesTest.kt
+++ b/generator/src/test/kotlin/com/android/gradle/replicator/generator/BasicAndroidWithResourcesTest.kt
@@ -58,12 +58,18 @@ class BasicAndroidWithResourcesTest: BaseTest() {
           {
             "qualifiers": "",
             "extension": ".xml",
-            "quantity": 1
+            "quantity": 1,
+            "fileSizes": [
+              64
+            ]
           },
           {
             "qualifiers": "v24",
             "extension": ".xml",
-            "quantity": 1
+            "quantity": 1,
+            "fileSizes": [
+              128
+            ]
           }
         ],
         "font": [],
@@ -85,32 +91,56 @@ class BasicAndroidWithResourcesTest: BaseTest() {
           {
             "qualifiers": "anydpi-v26",
             "extension": ".xml",
-            "quantity": 2
+            "quantity": 2,
+            "fileSizes": [
+              256,
+              512
+            ]
           },
           {
             "qualifiers": "hdpi",
             "extension": ".webp",
-            "quantity": 2
+            "quantity": 2,
+            "fileSizes": [
+              1024,
+              2048
+            ]
           },
           {
             "qualifiers": "mdpi",
             "extension": ".webp",
-            "quantity": 2
+            "quantity": 2,
+            "fileSizes": [
+              4096,
+              8192
+            ]
           },
           {
             "qualifiers": "xhdpi",
             "extension": ".webp",
-            "quantity": 2
+            "quantity": 2,
+            "fileSizes": [
+              16384,
+              32768
+            ]
           },
           {
             "qualifiers": "xxhdpi",
             "extension": ".webp",
-            "quantity": 2
+            "quantity": 2,
+            "fileSizes": [
+              65536,
+              131072
+            ]
           },
           {
             "qualifiers": "xxxhdpi",
             "extension": ".webp",
-            "quantity": 2
+            "quantity": 2,
+            "fileSizes": [
+              262144,
+              524288
+            ]
           }
         ],
         "raw": [],
@@ -119,12 +149,104 @@ class BasicAndroidWithResourcesTest: BaseTest() {
           {
             "qualifiers": "",
             "extension": ".xml",
-            "quantity": 4
+            "quantity": 4,
+            "valuesFileList": [
+              {
+                "stringCount": 5,
+                "intCount": 0,
+                "boolCount": 0,
+                "colorCount": 0,
+                "dimenCount": 0,
+                "idCount": 0,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              },
+              {
+                "stringCount": 2,
+                "intCount": 6,
+                "boolCount": 0,
+                "colorCount": 0,
+                "dimenCount": 0,
+                "idCount": 0,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              },
+              {
+                "stringCount": 2,
+                "intCount": 6,
+                "boolCount": 0,
+                "colorCount": 1,
+                "dimenCount": 0,
+                "idCount": 0,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              },
+              {
+                "stringCount": 2,
+                "intCount": 6,
+                "boolCount": 0,
+                "colorCount": 2,
+                "dimenCount": 1,
+                "idCount": 0,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              }
+            ]
           },
           {
             "qualifiers": "night",
             "extension": ".xml",
-            "quantity": 4
+            "quantity": 4,
+            "valuesFileList": [
+              {
+                "stringCount": 5,
+                "intCount": 0,
+                "boolCount": 0,
+                "colorCount": 0,
+                "dimenCount": 0,
+                "idCount": 2,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              },
+              {
+                "stringCount": 2,
+                "intCount": 6,
+                "boolCount": 0,
+                "colorCount": 0,
+                "dimenCount": 0,
+                "idCount": 2,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              },
+              {
+                "stringCount": 2,
+                "intCount": 6,
+                "boolCount": 0,
+                "colorCount": 1,
+                "dimenCount": 0,
+                "idCount": 2,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              },
+              {
+                "stringCount": 2,
+                "intCount": 6,
+                "boolCount": 0,
+                "colorCount": 2,
+                "dimenCount": 1,
+                "idCount": 2,
+                "integerArrayCount": [],
+                "arrayCount": [],
+                "styleCount": []
+              }
+            ]
           }
         ],
         "xml": []
@@ -163,12 +285,18 @@ class BasicAndroidWithResourcesTest: BaseTest() {
                                       {
                                         "qualifiers": "",
                                         "extension": ".xml",
-                                        "quantity": 1
+                                        "quantity": 1,
+                                        "fileSizes": [
+                                          64
+                                        ]
                                       },
                                       {
                                         "qualifiers": "v24",
                                         "extension": ".xml",
-                                        "quantity": 1
+                                        "quantity": 1,
+                                        "fileSizes": [
+                                          128
+                                        ]
                                       }
                                     ],
                                     "font": [],
@@ -190,32 +318,56 @@ class BasicAndroidWithResourcesTest: BaseTest() {
                                       {
                                         "qualifiers": "anydpi-v26",
                                         "extension": ".xml",
-                                        "quantity": 2
+                                        "quantity": 2,
+                                        "fileSizes": [
+                                          256,
+                                          512
+                                        ]
                                       },
                                       {
                                         "qualifiers": "hdpi",
                                         "extension": ".webp",
-                                        "quantity": 2
+                                        "quantity": 2,
+                                        "fileSizes": [
+                                          1024,
+                                          2048
+                                        ]
                                       },
                                       {
                                         "qualifiers": "mdpi",
                                         "extension": ".webp",
-                                        "quantity": 2
+                                        "quantity": 2,
+                                        "fileSizes": [
+                                          4096,
+                                          8192
+                                        ]
                                       },
                                       {
                                         "qualifiers": "xhdpi",
                                         "extension": ".webp",
-                                        "quantity": 2
+                                        "quantity": 2,
+                                        "fileSizes": [
+                                          16384,
+                                          32768
+                                        ]
                                       },
                                       {
                                         "qualifiers": "xxhdpi",
                                         "extension": ".webp",
-                                        "quantity": 2
+                                        "quantity": 2,
+                                        "fileSizes": [
+                                          65536,
+                                          131072
+                                        ]
                                       },
                                       {
                                         "qualifiers": "xxxhdpi",
                                         "extension": ".webp",
-                                        "quantity": 2
+                                        "quantity": 2,
+                                        "fileSizes": [
+                                          262144,
+                                          524288
+                                        ]
                                       }
                                     ],
                                     "raw": [],
@@ -224,17 +376,111 @@ class BasicAndroidWithResourcesTest: BaseTest() {
                                       {
                                         "qualifiers": "",
                                         "extension": ".xml",
-                                        "quantity": 4
+                                        "quantity": 4,
+                                        "valuesFileList": [
+                                          {
+                                            "stringCount": 5,
+                                            "intCount": 0,
+                                            "boolCount": 0,
+                                            "colorCount": 0,
+                                            "dimenCount": 0,
+                                            "idCount": 0,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          },
+                                          {
+                                            "stringCount": 2,
+                                            "intCount": 6,
+                                            "boolCount": 0,
+                                            "colorCount": 0,
+                                            "dimenCount": 0,
+                                            "idCount": 0,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          },
+                                          {
+                                            "stringCount": 2,
+                                            "intCount": 6,
+                                            "boolCount": 0,
+                                            "colorCount": 1,
+                                            "dimenCount": 0,
+                                            "idCount": 0,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          },
+                                          {
+                                            "stringCount": 2,
+                                            "intCount": 6,
+                                            "boolCount": 0,
+                                            "colorCount": 2,
+                                            "dimenCount": 1,
+                                            "idCount": 0,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          }
+                                        ]
                                       },
                                       {
                                         "qualifiers": "night",
                                         "extension": ".xml",
-                                        "quantity": 4
+                                        "quantity": 4,
+                                        "valuesFileList": [
+                                          {
+                                            "stringCount": 5,
+                                            "intCount": 0,
+                                            "boolCount": 0,
+                                            "colorCount": 0,
+                                            "dimenCount": 0,
+                                            "idCount": 2,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          },
+                                          {
+                                            "stringCount": 2,
+                                            "intCount": 6,
+                                            "boolCount": 0,
+                                            "colorCount": 0,
+                                            "dimenCount": 0,
+                                            "idCount": 2,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          },
+                                          {
+                                            "stringCount": 2,
+                                            "intCount": 6,
+                                            "boolCount": 0,
+                                            "colorCount": 1,
+                                            "dimenCount": 0,
+                                            "idCount": 2,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          },
+                                          {
+                                            "stringCount": 2,
+                                            "intCount": 6,
+                                            "boolCount": 0,
+                                            "colorCount": 2,
+                                            "dimenCount": 1,
+                                            "idCount": 2,
+                                            "integerArrayCount": [],
+                                            "arrayCount": [],
+                                            "styleCount": []
+                                          }
+                                        ]
                                       }
                                     ],
                                     "xml": []
                                   },
-                                  "javaResources": 2
+                                  "javaResources": {
+                                    "fileCount": 2
+                                  }
                                 }
                         """.trimIndent()
         )

--- a/model/src/main/kotlin/com/android/gradle/replicator/model/AndroidResourcesInfo.kt
+++ b/model/src/main/kotlin/com/android/gradle/replicator/model/AndroidResourcesInfo.kt
@@ -16,16 +16,7 @@
 
 package com.android.gradle.replicator.model
 
-/* Data classes to represent the hierarchy for android resources
- * Each resource folder type (values, mipmap, etc.) can have different qualified folders (hidpi, night, etc.)
- * and each of those qualified folders can have different file types in them (AKA extensions)
- * Each element in the resource map is a list of resources to generate for a given folder type, and
- * the elements in the list contain qualifiers, extension and quantity of resources of a particular subtype to generate
- */
-
-data class AndroidResourceProperties (val qualifiers: String, val extension: String, val quantity: Int)
-
-typealias AndroidResourceMap = MutableMap<String, MutableList<AndroidResourceProperties>>
+import com.android.gradle.replicator.model.internal.resources.AndroidResourceMap
 
 /**
  * Information about the number of android resource files in a [ModuleInfo]

--- a/model/src/main/kotlin/com/android/gradle/replicator/model/internal/DefaultAndroidResourcesInfo.kt
+++ b/model/src/main/kotlin/com/android/gradle/replicator/model/internal/DefaultAndroidResourcesInfo.kt
@@ -16,8 +16,12 @@
 
 package com.android.gradle.replicator.model.internal
 
-import com.android.gradle.replicator.model.internal.resources.AndroidResourceMap
 import com.android.gradle.replicator.model.AndroidResourcesInfo
+import com.android.gradle.replicator.model.internal.resources.AndroidResourceMap
+import com.android.gradle.replicator.model.internal.resources.ResourcePropertyType
+import com.android.gradle.replicator.model.internal.resources.AndroidValuesResourceProperties
+import com.android.gradle.replicator.model.internal.resources.AndroidSizeMattersResourceProperties
+import com.android.gradle.replicator.model.internal.resources.ValuesMap
 import com.android.gradle.replicator.model.internal.resources.selectResourceProperties
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
@@ -33,22 +37,38 @@ data class DefaultAndroidResourcesInfo(
  *         {
  *             "qualifiers": "",
  *             "extension": ".xml",
- *             "quantity": 2
+ *             "quantity": 2,
+ *             "fileSizes": [
+ *               5606,
+ *               1702
+ *             ]
  *         },
  *         {
  *             "qualifiers": "mod1",
  *             "extension": ".xml",
- *             "quantity": 3
+ *             "quantity": 3,
+ *             "fileSizes": [
+ *               5606,
+ *               2293,
+ *               1702
+ *             ]
  *         },
  *         {
  *             "qualifiers": "mod2",
  *             "extension": ".xml",
- *             "quantity": 2
+ *             "quantity": 2,
+ *             "fileSizes": [
+ *               5606,
+ *               1702
+ *             ]
  *         },
  *         {
  *             "qualifiers": "mod2",
  *             "extension": ".png",
- *             "quantity": 1
+ *             "quantity": 1,
+ *             "fileSizes": [
+ *               5606
+ *             ]
  *         }
  *     ],
  * ...
@@ -58,15 +78,58 @@ class AndroidResourcesAdapter: TypeAdapter<AndroidResourcesInfo>() {
     override fun write(output: JsonWriter, value: AndroidResourcesInfo) {
         output.beginObject()
         for (resourceType in value.resourceMap) {
-            val folderObject = output.name(resourceType.key).beginArray()
+            output.name(resourceType.key).beginArray()
             for (resourceProperties in resourceType.value) {
-                val resourceObject = folderObject.beginObject()
-                resourceObject.name("qualifiers").value(resourceProperties.qualifiers)
-                resourceObject.name("extension").value(resourceProperties.extension)
-                resourceObject.name("quantity").value(resourceProperties.quantity)
-                resourceObject.endObject()
+                output.beginObject()
+                output.name("qualifiers").value(resourceProperties.qualifiers)
+                output.name("extension").value(resourceProperties.extension)
+                output.name("quantity").value(resourceProperties.quantity)
+                when (resourceProperties.propertyType) {
+                    ResourcePropertyType.VALUES -> {
+                        output.name("valuesFileList").beginArray()
+                        (resourceProperties as AndroidValuesResourceProperties).valuesMapPerFile.forEach { resourceFile ->
+                            output.beginObject()
+                            output.name("stringCount").value(resourceFile.stringCount)
+                            output.name("intCount").value(resourceFile.intCount)
+                            output.name("boolCount").value(resourceFile.boolCount)
+                            output.name("colorCount").value(resourceFile.colorCount)
+                            output.name("dimenCount").value(resourceFile.dimenCount)
+                            output.name("idCount").value(resourceFile.idCount)
+
+                            output.name("integerArrayCount").beginArray()
+                            resourceFile.integerArrayCount.forEach {
+                                output.value(it)
+                            }
+                            output.endArray()
+
+                            output.name("arrayCount").beginArray()
+                            resourceFile.arrayCount.forEach {
+                                output.value(it)
+                            }
+                            output.endArray()
+
+                            output.name("styleCount").beginArray()
+                            resourceFile.styleCount.forEach {
+                                output.value(it)
+                            }
+                            output.endArray()
+
+                            output.endObject()
+                        }
+                        output.endArray()
+                    }
+                    ResourcePropertyType.SIZE_MATTERS -> {
+                        output.name("fileSizes").beginArray()
+                        (resourceProperties as AndroidSizeMattersResourceProperties).fileSizes.forEach { resourceFile ->
+                            output.value(resourceFile)
+                        }
+                        output.endArray()
+                    }
+                    ResourcePropertyType.DEFAULT -> {} // No additional information
+                }
+                output.endObject()
             }
-            folderObject.endArray()
+            output.endArray()
         }
         output.endObject()
     }
@@ -75,15 +138,15 @@ class AndroidResourcesAdapter: TypeAdapter<AndroidResourcesInfo>() {
         val fileCount: AndroidResourceMap = mutableMapOf()
 
         // Read folder properties
-        input.readObjectProperties { folderName ->
-            fileCount[folderName] = mutableListOf()
+        input.readObjectProperties { resourceType ->
+            fileCount[resourceType] = mutableListOf()
             // Read resource properties
             this.readArray {
                 var qualifiers: String? = null
                 var extension: String? = null
                 var quantity: Int? = null
                 var fileSizes: MutableList<Long>? = null
-                var valueTypeCount: MutableList<Map<String, Int>>? = null
+                var valuesMapPerFile: MutableList<ValuesMap>? = null
                 this.readObjectProperties { property ->
                     when (property) {
                         "qualifiers" -> qualifiers = this.nextString()
@@ -95,20 +158,47 @@ class AndroidResourcesAdapter: TypeAdapter<AndroidResourcesInfo>() {
                                 fileSizes!!.add(this.nextLong())
                             }
                         }
-                        "valueTypeCount" -> {
-                            valueTypeCount = mutableListOf()
+                        "valuesFileList" -> {
+                            valuesMapPerFile = mutableListOf()
                             this.readArray {
-                                val currFileCount = mutableMapOf<String, Int>()
+                                val valuesMap = ValuesMap()
                                 this.readObjectProperties { valueProperty ->
-                                    currFileCount[valueProperty] = this.nextInt()
+                                    when (valueProperty) {
+                                        "stringCount" -> { valuesMap.stringCount = this.nextInt() }
+                                        "intCount" -> { valuesMap.intCount = this.nextInt() }
+                                        "boolCount" -> { valuesMap.boolCount = this.nextInt()  }
+                                        "colorCount" -> { valuesMap.colorCount = this.nextInt()  }
+                                        "dimenCount" -> { valuesMap.dimenCount = this.nextInt()  }
+                                        "idCount" -> { valuesMap.idCount = this.nextInt() }
+                                        "integerArrayCount" -> {
+                                            this.readArray {
+                                                valuesMap.integerArrayCount.add(this.nextInt())
+                                            }
+                                        }
+                                        "arrayCount" -> {
+                                            this.readArray {
+                                                valuesMap.arrayCount.add(this.nextInt())
+                                            }
+                                        }
+                                        "styleCount" -> {
+                                            this.readArray {
+                                                valuesMap.styleCount.add(this.nextInt())
+                                            }
+                                        }
+                                    }
                                 }
-                                valueTypeCount!!.add(currFileCount)
+                                valuesMapPerFile!!.add(valuesMap)
                             }
                         }
                     }
                 }
-                fileCount[folderName]!!.add(selectResourceProperties(
-                        qualifiers!!, extension!!, qualifiers!!, quantity!!, fileSizes, valueTypeCount))
+                fileCount[resourceType]!!.add(selectResourceProperties(
+                    resourceType = resourceType,
+                    qualifiers = qualifiers!!,
+                    extension = extension!!,
+                    quantity = quantity!!,
+                    fileSizes = fileSizes,
+                    valuesMapPerFile = valuesMapPerFile))
             }
         }
 

--- a/model/src/main/kotlin/com/android/gradle/replicator/model/internal/resources/ResourceData.kt
+++ b/model/src/main/kotlin/com/android/gradle/replicator/model/internal/resources/ResourceData.kt
@@ -1,0 +1,62 @@
+package com.android.gradle.replicator.model.internal.resources
+
+// Supported file types of each resource. Not exhaustive.
+val ANDROID_RESOURCE_FOLDER_CONVENTION = mapOf(
+        "animator" to listOf(".xml"),
+        "anim" to listOf(".xml"),
+        "color" to listOf(".xml"),
+        "drawable" to listOf(".xml", ".png", ".9.png", ".jpg", ".gif", ".webp"),
+        "font" to listOf(".ttf", ".otf", ".ttc", ".xml"),
+        "layout" to listOf(".xml"),
+        "menu" to listOf(".xml"),
+        "mipmap" to listOf(".xml", ".png", ".9.png", ".jpg", ".gif", ".webp"),
+        "raw" to listOf("*"),
+        "transition" to listOf(".xml"),
+        "values" to listOf(".xml"),
+        "xml" to listOf(".xml")
+)
+
+/* Data classes to represent the hierarchy for android resources
+ * Each resource folder type (values, mipmap, etc.) can have different qualified folders (hidpi, night, etc.)
+ * and each of those qualified folders can have different file types in them (AKA extensions)
+ * Each element in the resource map is a list of resources to generate for a given folder type, and
+ * the elements in the list contain qualifiers, extension and quantity of resources of a particular subtype to generate
+ */
+abstract class AbstractAndroidResourceProperties (val qualifiers: String, val extension: String, val quantity: Int)
+
+class AndroidDefaultResourceProperties (
+        qualifiers: String,
+        extension: String,
+        quantity: Int): AbstractAndroidResourceProperties(qualifiers, extension, quantity)
+
+// Values need to know how many of each value are in the files
+class AndroidValuesResourceProperties (
+        qualifiers: String,
+        extension: String,
+        quantity: Int,
+        val valueTypeCount: List<Map<String, Int>>): AbstractAndroidResourceProperties(qualifiers, extension, quantity)
+
+// Images and other resources need the file sizes to properly replicate
+class AndroidSizeMattersResourceProperties (
+        qualifiers: String,
+        extension: String,
+        quantity: Int,
+        val fileSizes: List<Long>): AbstractAndroidResourceProperties(qualifiers, extension, quantity)
+
+typealias AndroidResourceMap = MutableMap<String, MutableList<AbstractAndroidResourceProperties>>
+
+fun selectResourceProperties(
+        resourceType: String,
+        qualifiers: String,
+        extension: String,
+        quantity: Int,
+        fileSizes: List<Long>? = null,
+        valueTypeCount: List<Map<String, Int>>? = null): AbstractAndroidResourceProperties {
+    return when (resourceType) {
+        "values" -> AndroidValuesResourceProperties(qualifiers, extension, quantity, valueTypeCount!!)
+        "drawable",
+        "mipmap",
+        "raw" -> AndroidSizeMattersResourceProperties(qualifiers, extension, quantity, fileSizes!!)
+        else -> AndroidDefaultResourceProperties(qualifiers, extension, quantity)
+    }
+}

--- a/model/src/main/kotlin/com/android/gradle/replicator/model/internal/resources/ResourceData.kt
+++ b/model/src/main/kotlin/com/android/gradle/replicator/model/internal/resources/ResourceData.kt
@@ -22,26 +22,51 @@ val ANDROID_RESOURCE_FOLDER_CONVENTION = mapOf(
  * Each element in the resource map is a list of resources to generate for a given folder type, and
  * the elements in the list contain qualifiers, extension and quantity of resources of a particular subtype to generate
  */
-abstract class AbstractAndroidResourceProperties (val qualifiers: String, val extension: String, val quantity: Int)
+abstract class AbstractAndroidResourceProperties (val qualifiers: String, val extension: String, val quantity: Int) {
+        abstract val propertyType: ResourcePropertyType
+}
+
+enum class ResourcePropertyType {
+        DEFAULT,
+        VALUES,
+        SIZE_MATTERS
+}
 
 class AndroidDefaultResourceProperties (
         qualifiers: String,
         extension: String,
-        quantity: Int): AbstractAndroidResourceProperties(qualifiers, extension, quantity)
+        quantity: Int): AbstractAndroidResourceProperties(qualifiers, extension, quantity) {
+                override val propertyType = ResourcePropertyType.DEFAULT
+}
+
+data class ValuesMap (
+        var stringCount: Int = 0,
+        var intCount: Int = 0,
+        var boolCount: Int = 0,
+        var colorCount: Int = 0,
+        var dimenCount: Int = 0,
+        var idCount: Int = 0,
+        var integerArrayCount: MutableList<Int> = mutableListOf(),
+        var arrayCount: MutableList<Int> = mutableListOf(),
+        var styleCount: MutableList<Int> = mutableListOf())
 
 // Values need to know how many of each value are in the files
 class AndroidValuesResourceProperties (
         qualifiers: String,
         extension: String,
         quantity: Int,
-        val valueTypeCount: List<Map<String, Int>>): AbstractAndroidResourceProperties(qualifiers, extension, quantity)
+        val valuesMapPerFile: List<ValuesMap>): AbstractAndroidResourceProperties(qualifiers, extension, quantity) {
+                override val propertyType = ResourcePropertyType.VALUES
+}
 
 // Images and other resources need the file sizes to properly replicate
 class AndroidSizeMattersResourceProperties (
         qualifiers: String,
         extension: String,
         quantity: Int,
-        val fileSizes: List<Long>): AbstractAndroidResourceProperties(qualifiers, extension, quantity)
+        val fileSizes: List<Long>): AbstractAndroidResourceProperties(qualifiers, extension, quantity) {
+                override val propertyType = ResourcePropertyType.SIZE_MATTERS
+}
 
 typealias AndroidResourceMap = MutableMap<String, MutableList<AbstractAndroidResourceProperties>>
 
@@ -51,9 +76,9 @@ fun selectResourceProperties(
         extension: String,
         quantity: Int,
         fileSizes: List<Long>? = null,
-        valueTypeCount: List<Map<String, Int>>? = null): AbstractAndroidResourceProperties {
+        valuesMapPerFile: List<ValuesMap>? = null): AbstractAndroidResourceProperties {
     return when (resourceType) {
-        "values" -> AndroidValuesResourceProperties(qualifiers, extension, quantity, valueTypeCount!!)
+        "values" -> AndroidValuesResourceProperties(qualifiers, extension, quantity, valuesMapPerFile!!)
         "drawable",
         "mipmap",
         "raw" -> AndroidSizeMattersResourceProperties(qualifiers, extension, quantity, fileSizes!!)

--- a/model/src/test/kotlin/com/android/gradle/replicator/model/internal/ModuleAdapterTest.kt
+++ b/model/src/test/kotlin/com/android/gradle/replicator/model/internal/ModuleAdapterTest.kt
@@ -19,9 +19,8 @@ package com.android.gradle.replicator.model.internal
 import com.android.gradle.replicator.model.*
 import com.android.gradle.replicator.model.internal.fixtures.module
 import com.android.gradle.replicator.model.internal.resources.AbstractAndroidResourceProperties
-import com.android.gradle.replicator.model.internal.resources.AndroidDefaultResourceProperties
-import com.android.gradle.replicator.model.internal.resources.AndroidSizeMattersResourceProperties
-import com.android.gradle.replicator.model.internal.resources.AndroidValuesResourceProperties
+import com.android.gradle.replicator.model.internal.resources.SizeMattersAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.resources.ValuesAndroidResourceProperties
 import com.android.gradle.replicator.model.internal.resources.ResourcePropertyType
 import com.android.gradle.replicator.model.internal.resources.ValuesMap
 import com.google.common.truth.Truth
@@ -93,25 +92,25 @@ internal class ModuleAdapterTest {
         androidResources {
             fileCount = mutableMapOf(
                     "mipmap" to mutableListOf<AbstractAndroidResourceProperties>(
-                            AndroidSizeMattersResourceProperties(
+                            SizeMattersAndroidResourceProperties(
                                 qualifiers = "",
                                 extension = ".xml",
                                 quantity = 3,
                                 fileSizes = listOf(64, 128, 256)
                             ),
-                            AndroidSizeMattersResourceProperties(
+                            SizeMattersAndroidResourceProperties(
                                 qualifiers = "",
                                 extension = ".png",
                                 quantity = 2,
                                 fileSizes = listOf(512, 1024)
                             ),
-                            AndroidSizeMattersResourceProperties(
+                            SizeMattersAndroidResourceProperties(
                                 qualifiers = "hidpi",
                                 extension = ".xml",
                                 quantity = 3,
                                 fileSizes = listOf(2048, 4096, 8192)
                             ),
-                            AndroidSizeMattersResourceProperties(
+                            SizeMattersAndroidResourceProperties(
                                 qualifiers = "hidpi",
                                 extension = ".png",
                                 quantity = 2,
@@ -119,7 +118,7 @@ internal class ModuleAdapterTest {
                             )
                     ),
                     "values" to mutableListOf<AbstractAndroidResourceProperties>(
-                            AndroidValuesResourceProperties(
+                            ValuesAndroidResourceProperties(
                                 qualifiers = "",
                                 extension = ".xml",
                                 quantity = 5,
@@ -180,14 +179,14 @@ internal class ModuleAdapterTest {
 
                 when (subjResourceProperties.propertyType) {
                     ResourcePropertyType.VALUES -> {
-                        val realSubjProperties = subjResourceProperties as AndroidValuesResourceProperties
-                        val realObjProperties = objResourceProperties as AndroidValuesResourceProperties
+                        val realSubjProperties = subjResourceProperties as ValuesAndroidResourceProperties
+                        val realObjProperties = objResourceProperties as ValuesAndroidResourceProperties
 
                         Truth.assertThat(realSubjProperties.valuesMapPerFile).isEqualTo(realObjProperties.valuesMapPerFile)
                     }
                     ResourcePropertyType.SIZE_MATTERS -> {
-                        val realSubjProperties = subjResourceProperties as AndroidSizeMattersResourceProperties
-                        val realObjProperties = objResourceProperties as AndroidSizeMattersResourceProperties
+                        val realSubjProperties = subjResourceProperties as SizeMattersAndroidResourceProperties
+                        val realObjProperties = objResourceProperties as SizeMattersAndroidResourceProperties
 
                         Truth.assertThat(realSubjProperties.fileSizes).isEqualTo(realObjProperties.fileSizes)}
                     ResourcePropertyType.DEFAULT -> { } // Nothing more

--- a/model/src/test/kotlin/com/android/gradle/replicator/model/internal/ModuleAdapterTest.kt
+++ b/model/src/test/kotlin/com/android/gradle/replicator/model/internal/ModuleAdapterTest.kt
@@ -18,6 +18,7 @@ package com.android.gradle.replicator.model.internal
 
 import com.android.gradle.replicator.model.*
 import com.android.gradle.replicator.model.internal.fixtures.module
+import com.android.gradle.replicator.model.internal.resources.AbstractAndroidResourceProperties
 import com.google.common.truth.Truth
 import org.junit.Test
 
@@ -87,13 +88,13 @@ internal class ModuleAdapterTest {
         androidResources {
             fileCount = mutableMapOf(
                     "mipmap" to mutableListOf(
-                            AndroidResourceProperties(qualifiers = "", extension = ".xml", quantity = 3),
-                            AndroidResourceProperties(qualifiers = "", extension = ".png", quantity = 2),
-                            AndroidResourceProperties(qualifiers = "hidpi", extension = ".xml", quantity = 3),
-                            AndroidResourceProperties(qualifiers = "hidpi", extension = ".png", quantity = 2)
+                            AbstractAndroidResourceProperties(qualifiers = "", extension = ".xml", quantity = 3),
+                            AbstractAndroidResourceProperties(qualifiers = "", extension = ".png", quantity = 2),
+                            AbstractAndroidResourceProperties(qualifiers = "hidpi", extension = ".xml", quantity = 3),
+                            AbstractAndroidResourceProperties(qualifiers = "hidpi", extension = ".png", quantity = 2)
                     ),
                     "values" to mutableListOf(
-                            AndroidResourceProperties(qualifiers = "", extension = ".xml", quantity = 5)
+                            AbstractAndroidResourceProperties(qualifiers = "", extension = ".xml", quantity = 5)
                     )
             )
         }

--- a/model/src/test/kotlin/com/android/gradle/replicator/model/internal/fixtures/AndroidResourcesBuilder.kt
+++ b/model/src/test/kotlin/com/android/gradle/replicator/model/internal/fixtures/AndroidResourcesBuilder.kt
@@ -1,6 +1,6 @@
 package com.android.gradle.replicator.model.internal.fixtures
 
-import com.android.gradle.replicator.model.AndroidResourceMap
+import com.android.gradle.replicator.model.internal.resources.AndroidResourceMap
 import com.android.gradle.replicator.model.AndroidResourcesInfo
 import com.android.gradle.replicator.model.internal.DefaultAndroidResourcesInfo
 

--- a/plugin/src/functionalTest/kotlin/com/android/gradle/replicator/BuildFeaturesTests.kt
+++ b/plugin/src/functionalTest/kotlin/com/android/gradle/replicator/BuildFeaturesTests.kt
@@ -754,7 +754,7 @@ class BuildFeaturesTests {
                   "extension": ".xml",
                   "quantity": 1,
                   "fileSizes": [
-                    321
+                    0
                   ]
                 },
                 {
@@ -762,7 +762,7 @@ class BuildFeaturesTests {
                   "extension": ".xml",
                   "quantity": 1,
                   "fileSizes": [
-                    321
+                    0
                   ]
                 }
               ],
@@ -787,8 +787,8 @@ class BuildFeaturesTests {
                   "extension": ".xml",
                   "quantity": 2,
                   "fileSizes": [
-                    321,
-                    321
+                    0,
+                    0
                   ]
                 },
                 {
@@ -926,7 +926,6 @@ class BuildFeaturesTests {
           "modules": []
         }
         """.trimIndent())
-
     }
 
     private fun setup(): ProjectSetup {

--- a/plugin/src/functionalTest/kotlin/com/android/gradle/replicator/BuildFeaturesTests.kt
+++ b/plugin/src/functionalTest/kotlin/com/android/gradle/replicator/BuildFeaturesTests.kt
@@ -692,12 +692,15 @@ class BuildFeaturesTests {
                 "mipmap-xxhdpi/ic_launcher_round.webp",
                 "mipmap-xxxhdpi/ic_launcher.webp",
                 "mipmap-xxxhdpi/ic_launcher_round.webp",
-                "navigation/nav_graph.xml",
-                "values/colors.xml",
-                "values/dimens.xml",
-                "values/strings.xml",
-                "values/themes.xml",
-                "values-night/themes.xml"
+                "navigation/nav_graph.xml"
+        )
+
+        val valuesResources = listOf(
+            "values/colors.xml",
+            "values/dimens.xml",
+            "values/strings.xml",
+            "values/themes.xml",
+            "values-night/themes.xml"
         )
 
         val javaResources = listOf(
@@ -709,6 +712,13 @@ class BuildFeaturesTests {
             val resourceFile = File(androidResourceFolder, it)
             resourceFile.parentFile.mkdirs()
             resourceFile.createNewFile()
+        }
+
+        valuesResources.forEach {
+            val resourceFile = File(androidResourceFolder, it)
+            resourceFile.parentFile.mkdirs()
+            resourceFile.createNewFile()
+            resourceFile.writeText("<resources>\n</resources>")
         }
 
         javaResources.forEach {
@@ -742,12 +752,18 @@ class BuildFeaturesTests {
                 {
                   "qualifiers": "",
                   "extension": ".xml",
-                  "quantity": 1
+                  "quantity": 1,
+                  "fileSizes": [
+                    321
+                  ]
                 },
                 {
                   "qualifiers": "v24",
                   "extension": ".xml",
-                  "quantity": 1
+                  "quantity": 1,
+                  "fileSizes": [
+                    321
+                  ]
                 }
               ],
               "font": [],
@@ -769,32 +785,56 @@ class BuildFeaturesTests {
                 {
                   "qualifiers": "anydpi-v26",
                   "extension": ".xml",
-                  "quantity": 2
+                  "quantity": 2,
+                  "fileSizes": [
+                    321,
+                    321
+                  ]
                 },
                 {
                   "qualifiers": "hdpi",
                   "extension": ".webp",
-                  "quantity": 2
+                  "quantity": 2,
+                  "fileSizes": [
+                    0,
+                    0
+                  ]
                 },
                 {
                   "qualifiers": "mdpi",
                   "extension": ".webp",
-                  "quantity": 2
+                  "quantity": 2,
+                  "fileSizes": [
+                    0,
+                    0
+                  ]
                 },
                 {
                   "qualifiers": "xhdpi",
                   "extension": ".webp",
-                  "quantity": 2
+                  "quantity": 2,
+                  "fileSizes": [
+                    0,
+                    0
+                  ]
                 },
                 {
                   "qualifiers": "xxhdpi",
                   "extension": ".webp",
-                  "quantity": 2
+                  "quantity": 2,
+                  "fileSizes": [
+                    0,
+                    0
+                  ]
                 },
                 {
                   "qualifiers": "xxxhdpi",
                   "extension": ".webp",
-                  "quantity": 2
+                  "quantity": 2,
+                  "fileSizes": [
+                    0,
+                    0
+                  ]
                 }
               ],
               "raw": [],
@@ -803,12 +843,71 @@ class BuildFeaturesTests {
                 {
                   "qualifiers": "",
                   "extension": ".xml",
-                  "quantity": 4
+                  "quantity": 4,
+                  "valuesFileList": [
+                    {
+                      "stringCount": 0,
+                      "intCount": 0,
+                      "boolCount": 0,
+                      "colorCount": 0,
+                      "dimenCount": 0,
+                      "idCount": 0,
+                      "integerArrayCount": [],
+                      "arrayCount": [],
+                      "styleCount": []
+                    },
+                    {
+                      "stringCount": 0,
+                      "intCount": 0,
+                      "boolCount": 0,
+                      "colorCount": 0,
+                      "dimenCount": 0,
+                      "idCount": 0,
+                      "integerArrayCount": [],
+                      "arrayCount": [],
+                      "styleCount": []
+                    },
+                    {
+                      "stringCount": 0,
+                      "intCount": 0,
+                      "boolCount": 0,
+                      "colorCount": 0,
+                      "dimenCount": 0,
+                      "idCount": 0,
+                      "integerArrayCount": [],
+                      "arrayCount": [],
+                      "styleCount": []
+                    },
+                    {
+                      "stringCount": 0,
+                      "intCount": 0,
+                      "boolCount": 0,
+                      "colorCount": 0,
+                      "dimenCount": 0,
+                      "idCount": 0,
+                      "integerArrayCount": [],
+                      "arrayCount": [],
+                      "styleCount": []
+                    }
+                  ]
                 },
                 {
                   "qualifiers": "night",
                   "extension": ".xml",
-                  "quantity": 1
+                  "quantity": 1,
+                  "valuesFileList": [
+                    {
+                      "stringCount": 0,
+                      "intCount": 0,
+                      "boolCount": 0,
+                      "colorCount": 0,
+                      "dimenCount": 0,
+                      "idCount": 0,
+                      "integerArrayCount": [],
+                      "arrayCount": [],
+                      "styleCount": []
+                    }
+                  ]
                 }
               ],
               "xml": []

--- a/plugin/src/functionalTest/kotlin/com/android/gradle/replicator/Fixtures.kt
+++ b/plugin/src/functionalTest/kotlin/com/android/gradle/replicator/Fixtures.kt
@@ -137,6 +137,9 @@ fun setupProject(
 ): ProjectSetup {
     // Setup the test build
     val projectDir = File("build/functionalTest/${getName(traceOffset)}")
+    if (projectDir.exists()) {
+        projectDir.deleteRecursively()
+    }
     projectDir.mkdirs()
     projectDir.resolve(type.settingsFile()).writeText("")
     val buildFile = projectDir.resolve(type.buidFile())

--- a/plugin/src/main/kotlin/com/android/gradle/replicator/GatherModuleInfoTask.kt
+++ b/plugin/src/main/kotlin/com/android/gradle/replicator/GatherModuleInfoTask.kt
@@ -158,11 +158,12 @@ abstract class GatherModuleInfoTask : DefaultTask() {
             resourceMap[conventionFolder.key] = mutableListOf()
 
             // Filter project folders by matching ones
-            val folderPattern = "${conventionFolder}(?:-(.*))?".toRegex()
+            val folderPattern = "${conventionFolder.key}(?:-(.*))?".toRegex()
 
             val matchingFolders = projectResourceFolders.filter {
                 folderPattern.matches(it.name)
             }
+
 
             for (projectFolder in matchingFolders) {
                 // Get folder qualifier, if any, such as mipmap-(hidpi). Qualifier is "" for unqualified folders
@@ -176,10 +177,10 @@ abstract class GatherModuleInfoTask : DefaultTask() {
                     }?.files
                     if (matchingResourceFiles != null && matchingResourceFiles.size > 0) {
                         resourceMap[conventionFolder.key]!!.add(processResourceFiles(
-                                resourceType = conventionFolder.key,
-                                qualifiers = qualifierMatch,
-                                extension = extension,
-                                resourceFiles = matchingResourceFiles
+                            resourceType = conventionFolder.key,
+                            qualifiers = qualifierMatch,
+                            extension = extension,
+                            resourceFiles = matchingResourceFiles
                         ))
                     }
                 }

--- a/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
+++ b/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
@@ -1,38 +1,45 @@
 package com.android.gradle.replicator
 
-import com.android.gradle.replicator.model.internal.resources.AbstractAndroidResourceProperties
-import com.android.gradle.replicator.model.internal.resources.AndroidDefaultResourceProperties
-import com.android.gradle.replicator.model.internal.resources.AndroidSizeMattersResourceProperties
-import com.android.gradle.replicator.model.internal.resources.AndroidValuesResourceProperties
+import com.android.gradle.replicator.model.internal.resources.*
+import com.android.utils.XmlUtils
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.Locator
+import org.xml.sax.helpers.DefaultHandler
 import java.io.File
-
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
 
 // Method to create the correct data class. Need to make this so it scans the files appropriately
 fun processResourceFiles(resourceType: String, qualifiers: String, extension: String, resourceFiles: Set<File>):
         AbstractAndroidResourceProperties {
-    return when(resourceType) {
+
+    val ret =  when(resourceType) {
         "values" -> getValuesResourceData(qualifiers, extension, resourceFiles)
         "drawable",
         "mipmap",
         "raw" -> getSizeMattersResourceData(qualifiers, extension, resourceFiles)
         else -> getDefaultResourceData(qualifiers, extension, resourceFiles)
     }
+
+    return ret
 }
 
-// Methods to parse specific resources
+// Methods to parse specific resource types
+// Parses values xml files and counts each type of value
 fun getValuesResourceData(qualifiers: String, extension: String, resourceFiles: Set<File>): AndroidValuesResourceProperties {
     return AndroidValuesResourceProperties(
             qualifiers = qualifiers,
             extension = extension,
             quantity = resourceFiles.size,
-            valueTypeCount = mutableListOf<Map<String, Int>>().apply {
+            valuesMapPerFile = mutableListOf<ValuesMap>().apply {
                 resourceFiles.forEach {
                     this.add(parseValuesFile(it))
                 }
             }
     )
-
 }
+
 fun getSizeMattersResourceData(qualifiers: String, extension: String, resourceFiles: Set<File>):
         AndroidSizeMattersResourceProperties {
     return AndroidSizeMattersResourceProperties(
@@ -55,6 +62,68 @@ fun getDefaultResourceData(qualifiers: String, extension: String, resourceFiles:
     )
 }
 
-fun parseValuesFile(valuesFile: File): Map<String, Int> {
-    return mapOf()
+
+fun parseValuesFile(valuesFile: File): ValuesMap {
+
+    val valuesMap = ValuesMap()
+
+    val handler: DefaultHandler = object : DefaultHandler() {
+        private var myDepth = 0
+        private var myLocator: Locator? = null
+        private var currentItemCount = 0
+        override fun setDocumentLocator(locator: Locator) {
+            myLocator = locator
+        }
+        override fun startElement(
+            uri: String, localName: String, qName: String, attributes: Attributes
+        ) {
+            myDepth++
+
+            if (myDepth == 3 && qName == "item") {
+                currentItemCount++
+            }
+
+            if (myDepth == 2) {
+                when (qName) {
+                    "string" -> { valuesMap.stringCount++ }
+                    "int" -> { valuesMap.intCount++ }
+                    "bool" -> { valuesMap.boolCount++  }
+                    "color" -> { valuesMap.colorCount++  }
+                    "dimen" -> { valuesMap.dimenCount++  }
+                    "item" -> { if (attributes.getValue("name") == "id") { valuesMap.idCount++ } }
+                    "integer-array" -> {} // Only add on close
+                    "array" -> {} // Only add on close
+                    "style" -> {} // Only add on close
+                    else -> {} // Ignore
+                }
+            }
+        }
+
+        override fun endElement(uri: String, localName: String, qName: String) {
+            if (myDepth == 2) {
+                when (qName) {
+                    "integer-array" -> {
+                        valuesMap.integerArrayCount.add(currentItemCount)
+                    }
+                    "array" -> {
+                        valuesMap.arrayCount.add(currentItemCount)
+                    }
+                    "style" -> {
+                        valuesMap.styleCount.add(currentItemCount)
+                    }
+                    else -> { }
+                }
+                currentItemCount = 0
+            }
+            myDepth--
+        }
+    }
+
+    val factory = SAXParserFactory.newInstance()
+    // Parse the input
+    XmlUtils.configureSaxFactory(factory, false, false)
+    val saxParser = XmlUtils.createSaxParser(factory)
+    saxParser.parse(InputSource(StringReader(valuesFile.readText())), handler)
+
+    return valuesMap
 }

--- a/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
+++ b/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
@@ -1,0 +1,60 @@
+package com.android.gradle.replicator
+
+import com.android.gradle.replicator.model.internal.resources.AbstractAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.resources.AndroidDefaultResourceProperties
+import com.android.gradle.replicator.model.internal.resources.AndroidSizeMattersResourceProperties
+import com.android.gradle.replicator.model.internal.resources.AndroidValuesResourceProperties
+import java.io.File
+
+
+// Method to create the correct data class. Need to make this so it scans the files appropriately
+fun processResourceFiles(resourceType: String, qualifiers: String, extension: String, resourceFiles: Set<File>):
+        AbstractAndroidResourceProperties {
+    return when(resourceType) {
+        "values" -> getValuesResourceData(qualifiers, extension, resourceFiles)
+        "drawable",
+        "mipmap",
+        "raw" -> getSizeMattersResourceData(qualifiers, extension, resourceFiles)
+        else -> getDefaultResourceData(qualifiers, extension, resourceFiles)
+    }
+}
+
+// Methods to parse specific resources
+fun getValuesResourceData(qualifiers: String, extension: String, resourceFiles: Set<File>): AndroidValuesResourceProperties {
+    return AndroidValuesResourceProperties(
+            qualifiers = qualifiers,
+            extension = extension,
+            quantity = resourceFiles.size,
+            valueTypeCount = mutableListOf<Map<String, Int>>().apply {
+                resourceFiles.forEach {
+                    this.add(parseValuesFile(it))
+                }
+            }
+    )
+
+}
+fun getSizeMattersResourceData(qualifiers: String, extension: String, resourceFiles: Set<File>):
+        AndroidSizeMattersResourceProperties {
+    return AndroidSizeMattersResourceProperties(
+            qualifiers = qualifiers,
+            extension = extension,
+            quantity = resourceFiles.size,
+            fileSizes = mutableListOf<Long>().apply {
+                resourceFiles.forEach {
+                    this.add(it.length())
+                }
+            }
+    )
+}
+
+fun getDefaultResourceData(qualifiers: String, extension: String, resourceFiles: Set<File>): AbstractAndroidResourceProperties {
+    return AndroidDefaultResourceProperties(
+            qualifiers = qualifiers,
+            extension = extension,
+            quantity = resourceFiles.size
+    )
+}
+
+fun parseValuesFile(valuesFile: File): Map<String, Int> {
+    return mapOf()
+}

--- a/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
+++ b/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
@@ -39,9 +39,14 @@ fun getValuesResourceData(qualifiers: String, extension: String, resourceFiles: 
             }
     )
 }
+private fun debugWrite(text: String) {
+    java.nio.file.Files.write(java.nio.file.Paths.get("/Users/jeanlucncoelho/debug.txt"), (text + "\n").toByteArray(), java.nio.file.StandardOpenOption.APPEND);
+}
+
 
 fun getSizeMattersResourceData(qualifiers: String, extension: String, resourceFiles: Set<File>):
         AndroidSizeMattersResourceProperties {
+    debugWrite("$qualifiers, $extension, $resourceFiles")
     return AndroidSizeMattersResourceProperties(
             qualifiers = qualifiers,
             extension = extension,


### PR DESCRIPTION
Project replicator will now gather some information about resources, such as file sizes and value resource amounts per type per file. This information is added to the model and passed on to the resource generator.

The resource generator does not yet use this information.

Also in this change:
* Fix a bug with vector drawable generators where image height or width could be rolled as zero.
* Fix a bug where the args parser would ignore an option it read from a properties file
* Add a properties file for tweaking resource generation
* Add language annotations to code strings