### PR TITLE
Add non-random resource generation and store generated resources in memory

### DIFF
--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/DrawableResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/DrawableResourceGenerator.kt
@@ -45,7 +45,7 @@ class DrawableResourceGenerator (params: ResourceGenerationParams): ResourceGene
             properties: AbstractAndroidResourceProperties,
             outputFolder: File
     ) {
-        // Sanity check
+        // Sanity check. This should not happen unless there is a bug in the metadata reader.
         if (properties.propertyType != ResourcePropertyType.DEFAULT) {
             throw RuntimeException ("Unexpected property type. Got ${properties.propertyType} instead of ${ResourcePropertyType.DEFAULT}")
         }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/FontResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/FontResourceGenerator.kt
@@ -15,7 +15,7 @@ class FontResourceGenerator(params: ResourceGenerationParams): ResourceGenerator
         properties: AbstractAndroidResourceProperties,
         outputFolder: File
     ) {
-        // Sanity check
+        // Sanity check. This should not happen unless there is a bug in the metadata reader.
         if (properties.propertyType != ResourcePropertyType.DEFAULT) {
             throw RuntimeException ("Unexpected property type. Got ${properties.propertyType} instead of ${ResourcePropertyType.DEFAULT}")
         }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/FontResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/FontResourceGenerator.kt
@@ -1,56 +1,68 @@
 package com.android.gradle.replicator.resgen
 
-import com.android.gradle.replicator.resgen.util.UniqueIdGenerator
+import com.android.gradle.replicator.model.internal.filedata.AbstractAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.filedata.DefaultAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.filedata.ResourcePropertyType
+import com.android.gradle.replicator.resgen.resourceModel.ResourceData
 import com.android.gradle.replicator.resgen.util.copyResourceFile
 import com.android.gradle.replicator.resgen.util.getFileType
-import com.android.gradle.replicator.resgen.util.getRandomResource
+import com.android.gradle.replicator.resgen.util.getResourceClosestToSize
 import java.io.File
-import kotlin.random.Random
 
-class FontResourceGenerator(
-    private val random: Random,
-    private val uniqueIdGenerator: UniqueIdGenerator): ResourceGenerator {
+class FontResourceGenerator(params: ResourceGenerationParams): ResourceGenerator(params) {
 
     override fun generateResource(
-            number: Int,
-            outputFolder: File,
-            resourceQualifiers: List<String>,
-            resourceExtension: String
+        properties: AbstractAndroidResourceProperties,
+        outputFolder: File
     ) {
-        if (getFileType(resourceExtension) == null) {
-            println("Unsupported file type $resourceExtension")
+        // Sanity check
+        if (properties.propertyType != ResourcePropertyType.DEFAULT) {
+            throw RuntimeException ("Unexpected property type. Got ${properties.propertyType} instead of ${ResourcePropertyType.DEFAULT}")
+        }
+        if (getFileType(properties.extension) == null) {
+            println("Unsupported file type $properties.extension")
             return
         }
-        repeat(number) {
-            val outputFile = File(outputFolder, "font_${uniqueIdGenerator.genIdByCategory("font.fileName")}.${resourceExtension}")
-            when (resourceExtension) {
+        (properties as DefaultAndroidResourceProperties).fileData.forEach { fileSize ->
+            val fileName = "font_${params.uniqueIdGenerator.genIdByCategory("font.fileName.${properties.qualifiers}")}"
+            val outputFile = File(outputFolder, "$fileName.${properties.extension}")
+            when (properties.extension) {
                 "xml" ->  {
                     println("Generating ${outputFile.absolutePath}")
-                    generateFontReferenceResource(outputFile, resourceQualifiers)
+                    generateFontReferenceResource(outputFile, properties.splitQualifiers, fileSize)
                 }
                 else -> {
                     println("Generating ${outputFile.absolutePath}")
-                    generateFontResource(outputFile, resourceQualifiers, resourceExtension)
+                    generateFontResource(outputFile, properties.extension, fileSize)
                 }
             }
+            params.resourceModel.resourceList.add(
+                ResourceData(
+                pkg = "",
+                name = fileName,
+                type = "font",
+                extension = properties.extension,
+                qualifiers = properties.splitQualifiers)
+            )
         }
     }
 
     private fun generateFontResource (
             outputFile: File,
-            resourceQualifiers: List<String>,
-            resourceExtension: String
+            resourceExtension: String,
+            fileSize: Long
     ) {
         val fileType = getFileType(resourceExtension)!!
 
-        val resourcePath = getRandomResource(random, fileType, resourceQualifiers) ?: return
+        val resourcePath = getResourceClosestToSize(fileType, fileSize) ?: return
 
         copyResourceFile(resourcePath, outputFile)
     }
 
     private fun generateFontReferenceResource (
             outputFile: File,
-            resourceQualifiers: List<String>
+            resourceQualifiers: List<String>,
+            fileSize: Long
     ) {
         // TODO: Implement this (needs resource context)
     }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/Main.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/Main.kt
@@ -22,6 +22,7 @@ import com.android.gradle.replicator.model.internal.*
 import com.android.gradle.replicator.model.internal.filedata.AndroidResourceMap
 import com.android.gradle.replicator.model.internal.filedata.FilesWithSizeMap
 import com.android.gradle.replicator.parsing.ArgsParser
+import com.android.gradle.replicator.resgen.resourceModel.ResourceModel
 import com.android.gradle.replicator.resgen.util.ResgenConstants
 import com.android.gradle.replicator.resgen.util.UniqueIdGenerator
 import com.google.gson.stream.JsonReader
@@ -123,10 +124,11 @@ class Main {
             resgenConstants: ResgenConstants) {
         val random = Random(parameters.seed)
         val uniqueIdGenerator = UniqueIdGenerator()
+        val resourceModel = ResourceModel()
         resMap.keys.sorted().forEach { resourceType ->
             val generator = GeneratorDriver(random, uniqueIdGenerator)
             resMap[resourceType]!!.sortedBy { it.qualifiers }.forEach { resourceProperties ->
-                generator.generateResources(outputFolder, resourceType, resourceProperties, resgenConstants)
+                generator.generateResources(outputFolder, resourceType, resourceProperties, resgenConstants, resourceModel)
             }
         }
     }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/RawResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/RawResourceGenerator.kt
@@ -1,43 +1,53 @@
 package com.android.gradle.replicator.resgen
 
-import com.android.gradle.replicator.resgen.util.UniqueIdGenerator
+import com.android.gradle.replicator.model.internal.filedata.AbstractAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.filedata.DefaultAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.filedata.ResourcePropertyType
+import com.android.gradle.replicator.resgen.resourceModel.ResourceData
 import com.android.gradle.replicator.resgen.util.copyResourceFile
 import com.android.gradle.replicator.resgen.util.getFileType
-import com.android.gradle.replicator.resgen.util.getRandomResource
+import com.android.gradle.replicator.resgen.util.getResourceClosestToSize
 import java.io.File
-import kotlin.random.Random
 
-class RawResourceGenerator (
-    private val random: Random,
-    private val uniqueIdGenerator: UniqueIdGenerator): ResourceGenerator {
-    var files = 0
-
+class RawResourceGenerator (params: ResourceGenerationParams): ResourceGenerator(params) {
     override fun generateResource(
-            number: Int,
-            outputFolder: File,
-            resourceQualifiers: List<String>,
-            resourceExtension: String
+        properties: AbstractAndroidResourceProperties,
+        outputFolder: File
     ) {
-        if (getFileType(resourceExtension) == null) {
-            println("Unsupported file type $resourceExtension")
+        // Sanity check
+        if (properties.propertyType != ResourcePropertyType.DEFAULT) {
+            throw RuntimeException ("Unexpected property type. Got ${properties.propertyType} instead of ${ResourcePropertyType.DEFAULT}")
+        }
+        if (getFileType(properties.extension) == null) {
+            println("Unsupported file type $properties.extension")
             return
         }
-        repeat(number) {
-            val outputFile = File(outputFolder, "raw_${uniqueIdGenerator.genIdByCategory("raw.fileName")}.${resourceExtension}")
+        (properties as DefaultAndroidResourceProperties).fileData.forEach { fileSize ->
+            val fileName = "raw_${params.uniqueIdGenerator.genIdByCategory("raw.fileName.${properties.qualifiers}")}"
+            val outputFile = File(outputFolder, "$fileName.${properties.extension}")
             println("Generating ${outputFile.absolutePath}")
-            generateRawResource(outputFile, resourceQualifiers, resourceExtension)
-            files++
+            generateRawResource(outputFile, properties.extension, fileSize)
+
+            params.resourceModel.resourceList.add(
+                ResourceData(
+                    pkg = "",
+                    name = fileName,
+                    type = "raw",
+                    extension = properties.extension,
+                    qualifiers = properties.splitQualifiers)
+            )
         }
     }
 
+    // TODO: generate random bytes for unknown resource types
     private fun generateRawResource (
             outputFile: File,
-            resourceQualifiers: List<String>,
-            resourceExtension: String
+            resourceExtension: String,
+            fileSize: Long
     ) {
         val fileType = getFileType(resourceExtension)!!
 
-        val resourcePath = getRandomResource(random, fileType, resourceQualifiers) ?: return
+        val resourcePath = getResourceClosestToSize(fileType, fileSize) ?: return
 
         copyResourceFile(resourcePath, outputFile)
     }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/RawResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/RawResourceGenerator.kt
@@ -14,7 +14,7 @@ class RawResourceGenerator (params: ResourceGenerationParams): ResourceGenerator
         properties: AbstractAndroidResourceProperties,
         outputFolder: File
     ) {
-        // Sanity check
+        // Sanity check. This should not happen unless there is a bug in the metadata reader.
         if (properties.propertyType != ResourcePropertyType.DEFAULT) {
             throw RuntimeException ("Unexpected property type. Got ${properties.propertyType} instead of ${ResourcePropertyType.DEFAULT}")
         }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ResourceGenerator.kt
@@ -16,25 +16,34 @@
  */
 package com.android.gradle.replicator.resgen
 
+import com.android.gradle.replicator.model.internal.filedata.AbstractAndroidResourceProperties
+import com.android.gradle.replicator.resgen.resourceModel.ResourceModel
+import com.android.gradle.replicator.resgen.util.ResgenConstants
+import com.android.gradle.replicator.resgen.util.UniqueIdGenerator
 import java.io.File
 import kotlin.random.Random
+
+data class ResourceGenerationParams(
+    val random: Random,
+    val constants: ResgenConstants,
+    val uniqueIdGenerator: UniqueIdGenerator,
+    val resourceModel: ResourceModel
+)
 
 /**
  * A ResourceGenerator is capable of generating a single type of resource files.
  */
 // TODO: return list of generated resources
 // TODO: make sure resources don't have the same name
-interface ResourceGenerator {
+abstract class ResourceGenerator (protected val params: ResourceGenerationParams) {
     /**
      * Generate a resource
      * @param outputFile the output file.
      * @param resourceQualifier the subtype of resource (hidpi, night, etc.).
      * @param resourceExtension the extension of the resource (xml, png, etc.).
      */
-    fun generateResource(
-            number: Int,
-            outputFolder: File,
-            resourceQualifiers: List<String>,
-            resourceExtension: String
+    abstract fun generateResource(
+        properties: AbstractAndroidResourceProperties,
+        outputFolder: File
     )
 }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ValueResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ValueResourceGenerator.kt
@@ -36,7 +36,7 @@ class ValueResourceGenerator (params: ResourceGenerationParams): ResourceGenerat
         properties: AbstractAndroidResourceProperties,
         outputFolder: File
     ) {
-        // Sanity check
+        // Sanity check. This should not happen unless there is a bug in the metadata reader.
         if (properties.propertyType != ResourcePropertyType.VALUES) {
             throw RuntimeException ("Unexpected property type. Got ${properties.propertyType} instead of ${ResourcePropertyType.VALUES}")
         }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ValueResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/ValueResourceGenerator.kt
@@ -16,76 +16,85 @@
  */
 package com.android.gradle.replicator.resgen
 
-import com.android.gradle.replicator.resgen.util.ResgenConstants
-import com.android.gradle.replicator.resgen.util.UniqueIdGenerator
+import com.android.gradle.replicator.model.internal.filedata.AbstractAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.filedata.ResourcePropertyType
+import com.android.gradle.replicator.model.internal.filedata.ValuesAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.filedata.ValuesMap
+import com.android.gradle.replicator.resgen.resourceModel.ResourceData
 import com.android.gradle.replicator.resgen.util.genHex
 import com.android.gradle.replicator.resgen.util.genString
 import com.android.gradle.replicator.resgen.util.genUniqueName
 import com.google.common.annotations.VisibleForTesting
 import java.io.File
-import kotlin.random.Random
 
-class ValueResourceGenerator (
-    private val random: Random,
-    private val constants: ResgenConstants,
-    private val uniqueIdGenerator: UniqueIdGenerator): ResourceGenerator {
+class ValueResourceGenerator (params: ResourceGenerationParams): ResourceGenerator(params) {
 
     @set:VisibleForTesting
     var numberOfResourceElements: Int?= null
 
     override fun generateResource(
-            number: Int,
-            outputFolder: File,
-            resourceQualifiers: List<String>,
-            resourceExtension: String
+        properties: AbstractAndroidResourceProperties,
+        outputFolder: File
     ) {
-        repeat(number) {
-            // TODO: Identify which kind of resource to generate
-            val type = ResourceType.VALUES
-            when (type) {
-                ResourceType.THEME ->  {
-                    val outputFile = File(outputFolder, "themes_${uniqueIdGenerator.genIdByCategory("values.fileName.theme")}.${resourceExtension}")
-                    println("Generating ${outputFile.absolutePath}")
-                    generateThemeResource(outputFile, resourceQualifiers)
-                }
-                ResourceType.VALUES -> {
-                    val outputFile = File(outputFolder, "values_${uniqueIdGenerator.genIdByCategory("values.fileName.values")}.${resourceExtension}")
-                    println("Generating ${outputFile.absolutePath}")
-                    generateXmlValueResource(outputFile)
-                }
+        // Sanity check
+        if (properties.propertyType != ResourcePropertyType.VALUES) {
+            throw RuntimeException ("Unexpected property type. Got ${properties.propertyType} instead of ${ResourcePropertyType.VALUES}")
+        }
+        (properties as ValuesAndroidResourceProperties).valuesMapPerFile.forEach {
+            // TODO: Sanity check style count vs other types
+            if (it.styleCount.size > 0)  { // Theme resource
+                val outputFile = File(outputFolder, "themes_${params.uniqueIdGenerator.genIdByCategory("values.fileName.theme")}.${properties.extension}")
+                println("Generating ${outputFile.absolutePath}")
+                generateThemeResource(outputFile, properties.splitQualifiers, it)
+            } else { // XML values resource
+                val outputFile = File(outputFolder, "values_${params.uniqueIdGenerator.genIdByCategory("values.fileName.values")}.${properties.extension}")
+                println("Generating ${outputFile.absolutePath}")
+                generateXmlValueResource(outputFile, properties.splitQualifiers, it)
             }
         }
     }
 
-    private enum class ValueType {
-        STRING, INT, BOOL, COLOR, DIMEN, ID, INT_ARRAY, TYPED_ARRAY
-    }
-
-    private enum class ResourceType {
-        VALUES, THEME
-    }
-
     private fun generateXmlValueResource (
-            outputFile: File
+            outputFile: File,
+            resourceQualifiers: List<String>,
+            valuesMap: ValuesMap
     ) {
-        val numberOfValues = numberOfResourceElements ?: random.nextInt(1, constants.values.MAX_VALUES)
-        val allValueTypes = ValueType.values()
+        // TODO: Randomize order of elements
 
         val xmlLines = mutableListOf<String>()
 
         xmlLines.add("<resources>")
 
-        repeat(numberOfValues) {
-            when(allValueTypes.random(random)) {
-                ValueType.STRING -> xmlLines.add(stringBlock())
-                ValueType.INT -> xmlLines.add(intBlock())
-                ValueType.BOOL -> xmlLines.add(boolBlock())
-                ValueType.COLOR -> xmlLines.add(colorBlock())
-                ValueType.DIMEN -> xmlLines.add(dimenBlock())
-                ValueType.ID -> xmlLines.add(idBlock())
-                ValueType.INT_ARRAY -> xmlLines.addAll(intArrayBlock())
-                ValueType.TYPED_ARRAY -> xmlLines.addAll(typedArrayBlock())
-            }
+        repeat(valuesMap.stringCount) {
+            xmlLines.add(stringBlock(resourceQualifiers))
+        }
+
+        repeat(valuesMap.intCount) {
+            xmlLines.add(intBlock(resourceQualifiers))
+        }
+
+        repeat(valuesMap.boolCount) {
+            xmlLines.add(boolBlock(resourceQualifiers))
+        }
+
+        repeat(valuesMap.colorCount) {
+            xmlLines.add(colorBlock(resourceQualifiers))
+        }
+
+        repeat(valuesMap.dimenCount) {
+            xmlLines.add(dimenBlock(resourceQualifiers))
+        }
+
+        repeat(valuesMap.idCount) {
+            xmlLines.add(idBlock(resourceQualifiers))
+        }
+
+        valuesMap.integerArrayCount.forEach {
+            xmlLines.addAll(intArrayBlock(resourceQualifiers))
+        }
+
+        valuesMap.arrayCount.forEach {
+            xmlLines.addAll(typedArrayBlock(resourceQualifiers))
         }
 
         xmlLines.add("</resources>")
@@ -95,74 +104,138 @@ class ValueResourceGenerator (
 
     private fun generateThemeResource (
             outputFile: File,
-            resourceQualifiers: List<String>
+            resourceQualifiers: List<String>,
+            valuesMap: ValuesMap
     ) {
         // To be implemented
         return
     }
 
-    private fun stringBlock (): String {
-        val name = genUniqueName(random, "values.resName.string", uniqueIdGenerator)
+    private fun stringBlock (resourceQualifiers: List<String>): String {
+        val name = genUniqueName(params.random, "values.resName.string.${resourceQualifiers}", params.uniqueIdGenerator)
         val value = genString(
-            constants.values.MAX_STRING_WORD_COUNT,
+            params.constants.values.MAX_STRING_WORD_COUNT,
             separator = " ",
-            random = random)
+            random = params.random)
+
+        params.resourceModel.resourceList.add(
+            ResourceData(
+                pkg = "",
+                name = name,
+                type = "values_string",
+                extension = "xml",
+                qualifiers = resourceQualifiers)
+        )
+
         return "    <string name=\"$name\">$value</string>"
     }
 
-    private fun intBlock (): String {
-        val name = genUniqueName(random, "values.resName.int", uniqueIdGenerator)
-        val value = random.nextInt()
+    private fun intBlock (resourceQualifiers: List<String>): String {
+        val name = genUniqueName(params.random, "values.resName.int.${resourceQualifiers}", params.uniqueIdGenerator)
+        val value = params.random.nextInt()
+
+        params.resourceModel.resourceList.add(
+            ResourceData(
+                pkg = "",
+                name = name,
+                type = "values_int",
+                extension = "xml",
+                qualifiers = resourceQualifiers)
+        )
+
         return "    <integer name=\"$name\">$value</integer>"
     }
 
-    private fun boolBlock (): String {
-        val name = genUniqueName(random, "values.resName.bool", uniqueIdGenerator)
-        val value = random.nextBoolean()
+    private fun boolBlock (resourceQualifiers: List<String>): String {
+        val name = genUniqueName(params.random, "values.resName.bool.${resourceQualifiers}", params.uniqueIdGenerator)
+        val value = params.random.nextBoolean()
+
+        params.resourceModel.resourceList.add(
+            ResourceData(
+                pkg = "",
+                name = name,
+                type = "values_bool",
+                extension = "xml",
+                qualifiers = resourceQualifiers)
+        )
+
         return "    <bool name=\"$name\">$value</bool>"
     }
 
-    private fun colorBlock (): String {
-        val name = genUniqueName(random, "values.resName.color", uniqueIdGenerator)
+    private fun colorBlock (resourceQualifiers: List<String>): String {
+        val name = genUniqueName(params.random, "values.resName.color.${resourceQualifiers}", params.uniqueIdGenerator)
         /* Digits can be:
          * #RGB
          * #ARGB
          * #RRGGBB
          * #AARRGGBB
          */
-        val numberOfDigits = constants.values.POSSIBLE_COLOR_DIGITS.random(random)
+        val numberOfDigits = params.constants.values.POSSIBLE_COLOR_DIGITS.random(params.random)
 
-        val value = genHex(numberOfDigits, random)
+        val value = genHex(numberOfDigits, params.random)
+
+        params.resourceModel.resourceList.add(
+            ResourceData(
+                pkg = "",
+                name = name,
+                type = "values_color",
+                extension = "xml",
+                qualifiers = resourceQualifiers)
+        )
 
         return "    <color name=\"$name\">#$value</color>"
     }
 
-    private fun dimenBlock (): String {
-        val name = genUniqueName(random, "values.resName.dimen", uniqueIdGenerator)
-        val value = "${random.nextInt(constants.values.MAX_DIMENSION)}${constants.values.DIMENSION_UNITS.random(random)}"
+    private fun dimenBlock (resourceQualifiers: List<String>): String {
+        val name = genUniqueName(params.random, "values.resName.dimen.${resourceQualifiers}", params.uniqueIdGenerator)
+        val value = "${params.random.nextInt(params.constants.values.MAX_DIMENSION)}${params.constants.values.DIMENSION_UNITS.random(params.random)}"
+        params.resourceModel.resourceList.add(
+            ResourceData(
+                pkg = "",
+                name = name,
+                type = "values_dimen",
+                extension = "xml",
+                qualifiers = resourceQualifiers)
+        )
 
         return "    <dimen name=\"$name\">$value</dimen>"
     }
 
-    private fun idBlock (): String {
-        val name = genUniqueName(random, "values.resName.id", uniqueIdGenerator)
+    private fun idBlock (resourceQualifiers: List<String>): String {
+        val name = genUniqueName(params.random, "values.resName.id.${resourceQualifiers}", params.uniqueIdGenerator)
+        params.resourceModel.resourceList.add(
+            ResourceData(
+                pkg = "",
+                name = name,
+                type = "values_id",
+                extension = "xml",
+                qualifiers = resourceQualifiers)
+        )
         return "    <item type=\"id\" name=\"$name\"/>"
     }
 
-    private fun intArrayBlock (): List<String> {
-        val name = genUniqueName(random, "values.resName.intArray", uniqueIdGenerator)
-        val size = random.nextInt(constants.values.MAX_ARRAY_ELEMENTS)
+    private fun intArrayBlock (resourceQualifiers: List<String>): List<String> {
+        val name = genUniqueName(params.random, "values.resName.intArray.${resourceQualifiers}", params.uniqueIdGenerator)
+        val size = params.random.nextInt(params.constants.values.MAX_ARRAY_ELEMENTS)
         val result = mutableListOf("    <integer-array name=\"$name\">")
 
         repeat(size) {
-            val value = random.nextInt()
+            val value = params.random.nextInt()
             result.add("        <item>$value</item>")
         }
         result.add("    </integer-array>")
+        params.resourceModel.resourceList.add(
+            ResourceData(
+                pkg = "",
+                name = name,
+                type = "values_int_array",
+                extension = "xml",
+                qualifiers = resourceQualifiers)
+        )
         return result
     }
 
-    private fun typedArrayBlock (): List<String> {
+    private fun typedArrayBlock (resourceQualifiers: List<String>): List<String> {
         // to be implemented
         return listOf()
     }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/resourceModel/ResourceModel.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/resourceModel/ResourceModel.kt
@@ -1,0 +1,13 @@
+package com.android.gradle.replicator.resgen.resourceModel
+
+data class ResourceData (
+    val pkg: String,
+    val name: String,
+    val type: String,
+    val extension: String,
+    val qualifiers: List<String>
+)
+
+class ResourceModel {
+    val resourceList: MutableList<ResourceData> = mutableListOf()
+}

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/PregenFileSelector.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/PregenFileSelector.kt
@@ -4,11 +4,22 @@ import org.reflections.Reflections
 import org.reflections.scanners.ResourcesScanner
 import java.io.File
 import java.io.FileOutputStream
+import kotlin.math.abs
 import kotlin.random.Random
 
 enum class FileTypes {
     PNG, NINE_PATCH, WEBP, JPEG, GIF, TEXT, JSON, TTF, OTF, TTC
 }
+
+/* Singleton cache of file sizes, so we don't recalculate them every time. Example:
+ * {
+ *   PNG: [("somefile.png", 523), ("anotherfile.png", 346), ("yetanotherfile.png", 456)],
+ *
+ *   WEBP: [("somefile.webp", 1237), ("anotherfile.webp", 2342), ("yetanotherfile.webp", 123)]
+ * }
+ */
+private data class FileData(val name: String, val size: Long)
+private val fileSizeCache = mutableMapOf<FileTypes, MutableList<FileData>>()
 
 private fun listResourceFiles(folder: String): List<String> {
     val reflections = Reflections("resgen", ResourcesScanner())
@@ -31,10 +42,13 @@ private fun getFolderFromType(type: FileTypes): String {
     return "resgen/$typeFolderName"
 }
 
-fun getRandomResource(random: Random, type: FileTypes, resourceQualifiers: List<String>): String? {
+fun getRandomResourceFromQualifiers(random: Random, type: FileTypes, resourceQualifiers: List<String>): String? {
     val qualifierPrefixes = resourceQualifiers.filter(String::isNotEmpty)
 
-    val allFiles = listResourceFiles(getFolderFromType(type))
+    // Cache is faster if it exists
+    val allFiles =
+        if (fileSizeCache[type] == null) listResourceFiles(getFolderFromType(type))
+        else fileSizeCache[type]!!.map { it.name }
 
     if (allFiles.isEmpty()) {
         println("e: no pre-generated $type file found")
@@ -49,6 +63,35 @@ fun getRandomResource(random: Random, type: FileTypes, resourceQualifiers: List<
 
     // If specific file does not exist, get generic one
     return if (filteredFiles.isEmpty()) allFiles.sorted().random(random) else filteredFiles.sorted().random(random)
+}
+
+fun getResourceClosestToSize(type: FileTypes, size: Long): String? {
+    if (fileSizeCache[type] == null) {
+        // Calculate cache
+        val allFiles = listResourceFiles(getFolderFromType(type))
+
+        fileSizeCache[type] = mutableListOf()
+
+        val loader = Thread.currentThread().contextClassLoader
+        allFiles.forEach { fileName ->
+            // getContentLengthLong gets the uncompressed file size
+            fileSizeCache[type]!!.add(
+                FileData(fileName, loader.getResource(fileName)!!.openConnection().contentLengthLong))
+        }
+    }
+    val cachedFiles = fileSizeCache[type]!!
+    if (cachedFiles.isEmpty()) {
+        println("e: no pre-generated $type file found")
+        return null
+    }
+    var closest = cachedFiles[0]
+    fileSizeCache[type]!!.forEach {
+        if (abs(it.size - size) < abs(closest.size - size)) {
+            closest = it
+        }
+    }
+    println("closest file to $size is ${closest.name} ${closest.size}")
+    return closest.name
 }
 
 fun copyResourceFile(resourcePath: String, output: File) {

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/PregenFileSelector.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/PregenFileSelector.kt
@@ -84,12 +84,7 @@ fun getResourceClosestToSize(type: FileTypes, size: Long): String? {
         println("e: no pre-generated $type file found")
         return null
     }
-    var closest = cachedFiles[0]
-    fileSizeCache[type]!!.forEach {
-        if (abs(it.size - size) < abs(closest.size - size)) {
-            closest = it
-        }
-    }
+    val closest = cachedFiles.minBy { abs(it.size - size) }!!
     println("closest file to $size is ${closest.name} ${closest.size}")
     return closest.name
 }

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/ResgenConstants.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/ResgenConstants.kt
@@ -10,10 +10,7 @@ class ResgenConstants (propertyFile: File? = null) {
     data class VectorImageConstants (
         val MAX_VECTOR_IMAGE_SIZE_SMALL: Int,
         val MAX_VECTOR_IMAGE_SIZE_MEDIUM: Int,
-        val MAX_VECTOR_IMAGE_SIZE_LARGE: Int,
-        val MAX_VECTOR_IMAGE_LINES_SMALL: Int,
-        val MAX_VECTOR_IMAGE_LINES_MEDIUM: Int,
-        val MAX_VECTOR_IMAGE_LINES_LARGE: Int)
+        val MAX_VECTOR_IMAGE_SIZE_LARGE: Int)
 
     data class ValuesConstants (
         val MAX_VALUES: Int,
@@ -34,9 +31,6 @@ class ResgenConstants (propertyFile: File? = null) {
         val maxVectorImageSizeSmall =  parser.option(propertyName = "maxVectorImageSizeSmall", argc = 1)
         val maxVectorImageSizeMedium =  parser.option(propertyName = "maxVectorImageSizeMedium", argc = 1)
         val maxVectorImageSizeLarge =  parser.option(propertyName = "maxVectorImageSizeLarge", argc = 1)
-        val maxVectorImageLinesSmall =  parser.option(propertyName = "maxVectorImageLinesSmall", argc = 1)
-        val maxVectorImageLinesMedium =  parser.option(propertyName = "maxVectorImageLinesMedium", argc = 1)
-        val maxVectorImageLinesLarge =  parser.option(propertyName = "maxVectorImageLinesLarge", argc = 1)
 
         // Values
         val maxValues =  parser.option(propertyName = "maxValues", argc = 1)
@@ -53,10 +47,7 @@ class ResgenConstants (propertyFile: File? = null) {
         vectorImage = VectorImageConstants(
             MAX_VECTOR_IMAGE_SIZE_SMALL = (maxVectorImageSizeSmall.orNull?.first?.toInt() ?: 100) + 1,
             MAX_VECTOR_IMAGE_SIZE_MEDIUM = (maxVectorImageSizeMedium.orNull?.first?.toInt() ?: 150) + 1,
-            MAX_VECTOR_IMAGE_SIZE_LARGE = (maxVectorImageSizeLarge.orNull?.first?.toInt() ?: 200) + 1,
-            MAX_VECTOR_IMAGE_LINES_SMALL = (maxVectorImageLinesSmall.orNull?.first?.toInt() ?: 50) + 1,
-            MAX_VECTOR_IMAGE_LINES_MEDIUM = (maxVectorImageLinesMedium.orNull?.first?.toInt() ?: 75) + 1,
-            MAX_VECTOR_IMAGE_LINES_LARGE = (maxVectorImageLinesLarge.orNull?.first?.toInt() ?: 100) + 1
+            MAX_VECTOR_IMAGE_SIZE_LARGE = (maxVectorImageSizeLarge.orNull?.first?.toInt() ?: 200) + 1
         )
 
         // same as above

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/VectorDrawableGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/util/VectorDrawableGenerator.kt
@@ -3,7 +3,7 @@ package com.android.gradle.replicator.resgen.util
 import kotlin.random.Random
 
 class VectorDrawableGenerator (val random: Random) {
-    fun generateImage(numberOfPathVectors: Int, maxVectorImageSize: Int): List<String> {
+    fun generateImage(numberOfPathVectors: Long, maxVectorImageSize: Int): List<String> {
         val lines = mutableListOf<String>()
         val width = random.nextInt(1, maxVectorImageSize)
         val height = random.nextInt(1, maxVectorImageSize)
@@ -21,7 +21,7 @@ class VectorDrawableGenerator (val random: Random) {
             ))
         }
         // Add random lines
-        repeat(numberOfPathVectors) {
+        for (i in 0..numberOfPathVectors) {
             lines.addAll(path(
                     fillColor = genHex(numberOfDigits = 8, random = random),
                     pathData = genStraightLinePathData(width, height),
@@ -32,6 +32,10 @@ class VectorDrawableGenerator (val random: Random) {
         }
         lines.add(endImage())
         return lines
+    }
+
+    fun getPathVectorsFromLines(lines: Long): Long {
+        return (lines - 7) / 6 // Header + footer is 7 lines and path vectors are 6 lines
     }
 
     private fun startImage(width: Int, height: Int, viewportWidth: Int, viewportHeight: Int): List<String> {

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/AbstractResourceGenerationTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/AbstractResourceGenerationTest.kt
@@ -17,6 +17,8 @@
 
 package com.android.gradle.replicator.resgen
 
+import com.android.gradle.replicator.resgen.resourceModel.ResourceModel
+import com.android.gradle.replicator.resgen.util.ResgenConstants
 import com.android.gradle.replicator.resgen.util.UniqueIdGenerator
 import org.junit.After
 import org.junit.Before
@@ -39,6 +41,9 @@ abstract class AbstractResourceGenerationTest {
     val testFolder = TemporaryFolder()
 
     lateinit var uniqueIdGenerator: UniqueIdGenerator
+
+    protected val resourceGenerationParams
+        get() = ResourceGenerationParams(random, ResgenConstants(), uniqueIdGenerator, ResourceModel())
 
     @Before
     fun setup() {

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
@@ -1,6 +1,6 @@
 package com.android.gradle.replicator.resgen
 
-import com.android.gradle.replicator.resgen.util.ResgenConstants
+import com.android.gradle.replicator.model.internal.filedata.DefaultAndroidResourceProperties
 import com.google.common.truth.Truth
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -9,140 +9,156 @@ import java.io.File
 class DrawableGenerationUnitTest: AbstractResourceGenerationTest() {
     @Test
     fun testDrawableGeneration() {
-        val generator = DrawableResourceGenerator(random, ResgenConstants(), uniqueIdGenerator)
+        val generator = DrawableResourceGenerator(resourceGenerationParams)
         generator.numberOfResourceElements = 3
 
         val pngFolder = testFolder.newFolder("png")
+        val pngQualifiedFolder = testFolder.newFolder("png-xxxhdpi")
         val jpgFolder = testFolder.newFolder("jpg")
         val ninePatchFolder = testFolder.newFolder("9png")
         val gifFolder = testFolder.newFolder("gif")
         val webpFolder = testFolder.newFolder("webp")
         val xmlFolder = testFolder.newFolder("xml")
+        val xmlQualifiedFolder = testFolder.newFolder("xml-hidpi-v24")
 
-        val expectedChosenImages = mapOf(
-                "image_aaaa.png" to
-                        Pair(pngFolder, getResourceImage("png", "anydpi_bootleg_android.png")),
-                "image_aaab.png" to
-                        Pair(pngFolder, getResourceImage("png", "anydpi_pizza.png")),
-                "image_aaac.jpg" to
-                        Pair(jpgFolder, getResourceImage("jpeg", "hdpi_bootleg_android.jpg")),
-                "image_aaad.jpg" to
-                        Pair(jpgFolder, getResourceImage("jpeg", "hdpi_pizza.jpg")),
-                "image_aaae.9.png" to
-                        Pair(ninePatchFolder, getResourceImage("9png", "ldpi_bootleg_android.9.png")),
-                "image_aaaf.9.png" to
-                        Pair(ninePatchFolder, getResourceImage("9png", "ldpi_pizza.9.png")),
-                "image_aaag.gif" to
-                        Pair(gifFolder, getResourceImage("gif", "mdpi_bootleg_android.gif")),
-                "image_aaah.gif" to
-                        Pair(gifFolder, getResourceImage("gif", "mdpi_pizza.gif")),
-                "image_aaai.webp" to
-                        Pair(webpFolder, getResourceImage("webp", "nodpi_bootleg_android.webp")),
-                "image_aaaj.webp" to
-                        Pair(webpFolder, getResourceImage("webp", "nodpi_pizza.webp")),
-                "image_aaak.png" to
-                        Pair(pngFolder, getResourceImage("png", "xxxhdpi_bootleg_android.png")),
-                "image_aaal.png" to
-                        Pair(pngFolder, getResourceImage("png", "xxxhdpi_pizza.png"))
+        data class FileEq(val fname: String, val folder: File, val feq: File)
+        val expectedChosenImages = listOf(
+            FileEq("image_aaaa.png", pngFolder, getResourceImage("png", "anydpi_bootleg_android.png")),
+            FileEq("image_aaab.png", pngFolder, getResourceImage("png", "anydpi_pizza.png")),
+            FileEq("image_aaac.jpg", jpgFolder, getResourceImage("jpeg", "hdpi_bootleg_android.jpg")),
+            FileEq("image_aaad.jpg", jpgFolder, getResourceImage("jpeg", "hdpi_pizza.jpg")),
+            FileEq("image_aaae.9.png", ninePatchFolder, getResourceImage("9png", "ldpi_bootleg_android.9.png")),
+            FileEq("image_aaaf.9.png", ninePatchFolder, getResourceImage("9png", "ldpi_pizza.9.png")),
+            FileEq("image_aaag.gif", gifFolder, getResourceImage("gif", "mdpi_bootleg_android.gif")),
+            FileEq("image_aaah.gif", gifFolder, getResourceImage("gif", "mdpi_pizza.gif")),
+            FileEq("image_aaai.webp", webpFolder, getResourceImage("webp", "nodpi_bootleg_android.webp")),
+            FileEq("image_aaaj.webp", webpFolder, getResourceImage("webp", "nodpi_pizza.webp")),
+            FileEq("image_aaaa.png", pngQualifiedFolder, getResourceImage("png", "xxxhdpi_bootleg_android.png")),
+            FileEq("image_aaab.png", pngQualifiedFolder, getResourceImage("png", "xxxhdpi_pizza.png"))
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = pngFolder,
-                resourceQualifiers = listOf(),
-                resourceExtension = "png"
+                properties = DefaultAndroidResourceProperties(
+                    qualifiers = "",
+                    extension = "png",
+                    quantity = 2,
+                    fileData = listOf(228000, 3300000)
+                ),
+                outputFolder = pngFolder
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = jpgFolder,
-                resourceQualifiers = listOf(),
-                resourceExtension = "jpg"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "jpg",
+                quantity = 2,
+                fileData = listOf(226000, 2300000)
+            ),
+            outputFolder = jpgFolder
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = ninePatchFolder,
-                resourceQualifiers = listOf(),
-                resourceExtension = "9.png"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "9.png",
+                quantity = 2,
+                fileData = listOf(135000, 1900000)
+            ),
+            outputFolder = ninePatchFolder
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = gifFolder,
-                resourceQualifiers = listOf(),
-                resourceExtension = "gif"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "gif",
+                quantity = 2,
+                fileData = listOf(295000, 931000)
+            ),
+            outputFolder = gifFolder
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = webpFolder,
-                resourceQualifiers = listOf(),
-                resourceExtension = "webp"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "webp",
+                quantity = 2,
+                fileData = listOf(23000, 227000)
+            ),
+            outputFolder = webpFolder
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = pngFolder,
-                resourceQualifiers = listOf("xxxhdpi"),
-                resourceExtension = "png"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "xxxhdpi",
+                extension = "png",
+                quantity = 2,
+                fileData = listOf(124000, 833000)
+            ),
+            outputFolder = pngQualifiedFolder
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = xmlFolder,
-                resourceQualifiers = listOf(),
-                resourceExtension = "xml"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "xml",
+                quantity = 2,
+                fileData = listOf(22, 19)
+            ),
+            outputFolder = xmlFolder
         )
 
         generator.generateResource(
-                number = 1,
-                outputFolder = xmlFolder,
-                resourceQualifiers = listOf("hidpi-v24"),
-                resourceExtension = "xml"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "hidpi-v24",
+                extension = "xml",
+                quantity = 1,
+                fileData = listOf(22)
+            ),
+            outputFolder = xmlQualifiedFolder
         )
 
-        Truth.assertThat(pngFolder.listFiles()!!.asList().map{it.name}).containsExactly(
-                "image_aaaa.png", "image_aaab.png", "image_aaak.png", "image_aaal.png")
+        Truth.assertThat(pngFolder.listFiles()!!.asList().map{it.name}).containsExactly("image_aaaa.png", "image_aaab.png")
+        Truth.assertThat(pngQualifiedFolder.listFiles()!!.asList().map{it.name}).containsExactly("image_aaaa.png", "image_aaab.png")
         Truth.assertThat(jpgFolder.listFiles()!!.asList().map{it.name}).containsExactly("image_aaac.jpg", "image_aaad.jpg")
         Truth.assertThat(ninePatchFolder.listFiles()!!.asList().map{it.name}).containsExactly("image_aaae.9.png", "image_aaaf.9.png")
         Truth.assertThat(gifFolder.listFiles()!!.asList().map{it.name}).containsExactly("image_aaag.gif", "image_aaah.gif")
         Truth.assertThat(webpFolder.listFiles()!!.asList().map{it.name}).containsExactly("image_aaai.webp", "image_aaaj.webp")
-        Truth.assertThat(xmlFolder.listFiles()!!.asList().map{it.name}).containsExactly("vector_drawable_aaaa.xml", "vector_drawable_aaab.xml", "vector_drawable_aaac.xml")
+        Truth.assertThat(xmlFolder.listFiles()!!.asList().map{it.name}).containsExactly("vector_drawable_aaaa.xml", "vector_drawable_aaab.xml")
+        Truth.assertThat(xmlQualifiedFolder.listFiles()!!.asList().map{it.name}).containsExactly("vector_drawable_aaaa.xml")
 
         expectedChosenImages.forEach {
-            Truth.assertThat(File(it.value.first, it.key).readBytes()).isEqualTo(it.value.second.readBytes())
+            Truth.assertThat(File(it.folder, it.fname).readBytes()).isEqualTo(it.feq.readBytes())
         }
 
         @Language("xml")
         val expectedXmlAAAA = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
-                android:width="13dp"
-                android:height="14dp"
-                android:viewportWidth="1"
+                android:width="1dp"
+                android:height="2dp"
+                android:viewportWidth="0"
                 android:viewportHeight="1">
                 <path
                     android:fillColor="#00010203"
-                    android:pathData="M0,0h13v14h-13z" />
+                    android:pathData="M0,0h1v2h-1z" />
                 <path
                     android:fillColor="#04050607"
                     android:strokeColor="#08090a0b"
-                    android:strokeWidth="0.02"
-                    android:fillAlpha="0.021"
-                    android:pathData="M3,3L5,5" />
+                    android:strokeWidth="0.008"
+                    android:fillAlpha="0.009"
+                    android:pathData="M0,1L0,1" />
                 <path
                     android:fillColor="#0c0d0e0f"
                     android:strokeColor="#10111213"
-                    android:strokeWidth="0.026"
-                    android:fillAlpha="0.027"
-                    android:pathData="M9,9L11,11" />
+                    android:strokeWidth="0.014"
+                    android:fillAlpha="0.015"
+                    android:pathData="M0,1L0,1" />
                 <path
                     android:fillColor="#14151617"
                     android:strokeColor="#18191a1b"
-                    android:strokeWidth="0.032"
-                    android:fillAlpha="0.033"
-                    android:pathData="M2,1L4,3" />
+                    android:strokeWidth="0.02"
+                    android:fillAlpha="0.021"
+                    android:pathData="M0,1L0,1" />
             </vector>
         """.trimIndent()
 
@@ -150,65 +166,65 @@ class DrawableGenerationUnitTest: AbstractResourceGenerationTest() {
         val expectedXmlAAAB = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
-                android:width="35dp"
-                android:height="36dp"
+                android:width="23dp"
+                android:height="24dp"
                 android:viewportWidth="1"
                 android:viewportHeight="1">
                 <path
                     android:fillColor="#1c1d1e1f"
                     android:strokeColor="#20212223"
-                    android:strokeWidth="0.042"
-                    android:fillAlpha="0.043"
+                    android:strokeWidth="0.03"
+                    android:fillAlpha="0.031"
                     android:pathData="M3,3L5,5" />
                 <path
                     android:fillColor="#24252627"
                     android:strokeColor="#28292a2b"
-                    android:strokeWidth="0.048"
-                    android:fillAlpha="0.049"
+                    android:strokeWidth="0.036"
+                    android:fillAlpha="0.037"
                     android:pathData="M9,9L11,11" />
                 <path
                     android:fillColor="#2c2d2e2f"
                     android:strokeColor="#30313233"
-                    android:strokeWidth="0.054"
-                    android:fillAlpha="0.055"
+                    android:strokeWidth="0.042"
+                    android:fillAlpha="0.043"
                     android:pathData="M15,15L17,17" />
             </vector>
         """.trimIndent()
 
         @Language("xml")
-        val expectedXmlAAAC = """
+        val expectedXmlAAAAHDPI = """
             <?xml version="1.0" encoding="utf-8"?>
             <vector xmlns:android="http://schemas.android.com/apk/res/android"
-                android:width="57dp"
-                android:height="58dp"
+                android:width="45dp"
+                android:height="46dp"
                 android:viewportWidth="1"
                 android:viewportHeight="1">
                 <path
                     android:fillColor="#34353637"
-                    android:pathData="M0,0h57v58h-57z" />
+                    android:pathData="M0,0h45v46h-45z" />
                 <path
                     android:fillColor="#38393a3b"
                     android:strokeColor="#3c3d3e3f"
-                    android:strokeWidth="0.064"
-                    android:fillAlpha="0.065"
+                    android:strokeWidth="0.052"
+                    android:fillAlpha="0.053"
                     android:pathData="M3,3L5,5" />
                 <path
                     android:fillColor="#40414243"
                     android:strokeColor="#44454647"
-                    android:strokeWidth="0.07"
-                    android:fillAlpha="0.071"
+                    android:strokeWidth="0.058"
+                    android:fillAlpha="0.059"
                     android:pathData="M9,9L11,11" />
                 <path
                     android:fillColor="#48494a4b"
                     android:strokeColor="#4c4d4e4f"
-                    android:strokeWidth="0.076"
-                    android:fillAlpha="0.077"
+                    android:strokeWidth="0.064"
+                    android:fillAlpha="0.065"
                     android:pathData="M15,15L17,17" />
             </vector>
         """.trimIndent()
 
         Truth.assertThat(File(xmlFolder, "vector_drawable_aaaa.xml").readText()).isEqualTo(expectedXmlAAAA)
         Truth.assertThat(File(xmlFolder, "vector_drawable_aaab.xml").readText()).isEqualTo(expectedXmlAAAB)
-        Truth.assertThat(File(xmlFolder, "vector_drawable_aaac.xml").readText()).isEqualTo(expectedXmlAAAC)
+        Truth.assertThat(File(xmlQualifiedFolder, "vector_drawable_aaaa.xml").readText()).isEqualTo(expectedXmlAAAAHDPI)
     }
 }

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/FontGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/FontGenerationUnitTest.kt
@@ -1,5 +1,6 @@
 package com.android.gradle.replicator.resgen
 
+import com.android.gradle.replicator.model.internal.filedata.DefaultAndroidResourceProperties
 import com.google.common.truth.Truth
 import org.junit.Test
 import java.io.File
@@ -7,7 +8,7 @@ import java.io.File
 class FontGenerationUnitTest: AbstractResourceGenerationTest() {
     @Test
     fun testFontGeneration() {
-        val generator = FontResourceGenerator(random, uniqueIdGenerator)
+        val generator = FontResourceGenerator(resourceGenerationParams)
 
         val expectedChosenImages = mapOf(
                 "font_aaaa.ttf" to
@@ -25,24 +26,33 @@ class FontGenerationUnitTest: AbstractResourceGenerationTest() {
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "ttf"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "ttf",
+                quantity = 2,
+                fileData = listOf(5000, 1300000)
+            ),
+            outputFolder = testFolder.root
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "otf"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "otf",
+                quantity = 2,
+                fileData = listOf(6332, 100000)
+            ),
+            outputFolder = testFolder.root
         )
 
         generator.generateResource(
-                number = 2,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "ttc"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "ttc",
+                quantity = 2,
+                fileData = listOf(19000000, 24000000)
+            ),
+            outputFolder = testFolder.root
         )
 
         Truth.assertThat(testFolder.root.listFiles()!!.asList().map { it.name }).containsExactly(

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/RawGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/RawGenerationUnitTest.kt
@@ -1,5 +1,6 @@
 package com.android.gradle.replicator.resgen
 
+import com.android.gradle.replicator.model.internal.filedata.DefaultAndroidResourceProperties
 import com.google.common.truth.Truth
 import org.junit.Test
 import java.io.File
@@ -7,7 +8,7 @@ import java.io.File
 class RawGenerationUnitTest: AbstractResourceGenerationTest() {
     @Test
     fun testRawGeneration() {
-        val generator = RawResourceGenerator(random, uniqueIdGenerator)
+        val generator = RawResourceGenerator(resourceGenerationParams)
 
         val expectedChosenImages = mapOf(
                 "raw_aaaa.txt" to
@@ -21,31 +22,43 @@ class RawGenerationUnitTest: AbstractResourceGenerationTest() {
         )
 
         generator.generateResource(
-                number = 1,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "txt"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "txt",
+                quantity = 1,
+                fileData = listOf(1535)
+            ),
+            outputFolder = testFolder.root
         )
 
         generator.generateResource(
-                number = 1,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "json"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "json",
+                quantity = 1,
+                fileData = listOf(600)
+            ),
+            outputFolder = testFolder.root
         )
 
         generator.generateResource(
-                number = 1,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "png"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "png",
+                quantity = 1,
+                fileData = listOf(318000)
+            ),
+            outputFolder = testFolder.root
         )
 
         generator.generateResource(
-                number = 1,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "jpg"
+            properties = DefaultAndroidResourceProperties(
+                qualifiers = "",
+                extension = "jpg",
+                quantity = 1,
+                fileData = listOf(2300000)
+            ),
+            outputFolder = testFolder.root
         )
 
         Truth.assertThat(testFolder.root.listFiles()!!.asList().map { it.name }).containsExactly(

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ResgenConstantsUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ResgenConstantsUnitTest.kt
@@ -19,9 +19,6 @@ class ResgenConstantsUnitTest {
             maxVectorImageSizeSmall=1
             maxVectorImageSizeMedium=2
             maxVectorImageSizeLarge=3
-            maxVectorImageLinesSmall=4
-            maxVectorImageLinesMedium=5
-            maxVectorImageLinesLarge=6
 
             # Values generation
             maxValues=7
@@ -38,9 +35,6 @@ class ResgenConstantsUnitTest {
         assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_SMALL).isEqualTo(2)
         assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_MEDIUM).isEqualTo(3)
         assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_LARGE).isEqualTo(4)
-        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_SMALL).isEqualTo(5)
-        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_MEDIUM).isEqualTo(6)
-        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_LARGE).isEqualTo(7)
 
         assertThat(resgenConstants.values.MAX_VALUES).isEqualTo(8)
         assertThat(resgenConstants.values.MAX_ARRAY_ELEMENTS).isEqualTo(9)
@@ -56,9 +50,6 @@ class ResgenConstantsUnitTest {
         assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_SMALL).isEqualTo(101)
         assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_MEDIUM).isEqualTo(151)
         assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_SIZE_LARGE).isEqualTo(201)
-        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_SMALL).isEqualTo(51)
-        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_MEDIUM).isEqualTo(76)
-        assertThat(resgenConstants.vectorImage.MAX_VECTOR_IMAGE_LINES_LARGE).isEqualTo(101)
 
         assertThat(resgenConstants.values.MAX_VALUES).isEqualTo(22)
         assertThat(resgenConstants.values.MAX_ARRAY_ELEMENTS).isEqualTo(21)

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ResourceGenerationIntegrationTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ResourceGenerationIntegrationTest.kt
@@ -32,10 +32,10 @@ class ResourceGenerationIntegrationTest: AbstractResourceGenerationTest() {
 
         Truth.assertThat(allResourceFiles).containsExactly(
             "mipmap-mdpi",
-            "mipmap-mdpi/image_aaae.webp",
-            "mipmap-mdpi/image_aaad.webp",
+            "mipmap-mdpi/image_aaaa.webp",
+            "mipmap-mdpi/image_aaab.webp",
             "drawable-v24",
-            "drawable-v24/vector_drawable_aaaf.xml",
+            "drawable-v24/vector_drawable_aaaa.xml",
             "mipmap-hdpi",
             "mipmap-hdpi/image_aaaa.webp",
             "mipmap-hdpi/image_aaab.webp",
@@ -46,27 +46,27 @@ class ResourceGenerationIntegrationTest: AbstractResourceGenerationTest() {
             "drawable/vector_drawable_aaad.xml",
             "drawable/vector_drawable_aaae.xml",
             "mipmap-xxxhdpi",
-            "mipmap-xxxhdpi/image_aaaj.webp",
-            "mipmap-xxxhdpi/image_aaak.webp",
+            "mipmap-xxxhdpi/image_aaaa.webp",
+            "mipmap-xxxhdpi/image_aaab.webp",
             "layout",
             "mipmap-xxhdpi",
-            "mipmap-xxhdpi/image_aaah.webp",
-            "mipmap-xxhdpi/image_aaai.webp",
+            "mipmap-xxhdpi/image_aaaa.webp",
+            "mipmap-xxhdpi/image_aaab.webp",
             "values-night",
-            "values-night/values_aaaf.xml",
+            "values-night/values_aaae.xml",
             "values",
             "values/values_aaaa.xml",
             "values/values_aaab.xml",
             "values/values_aaac.xml",
             "values/values_aaad.xml",
-            "values/values_aaae.xml",
+            //"values/values_aaae.xml", themes still not supported
             "menu",
             "mipmap-xhdpi",
-            "mipmap-xhdpi/image_aaaf.webp",
-            "mipmap-xhdpi/image_aaag.webp",
+            "mipmap-xhdpi/image_aaaa.webp",
+            "mipmap-xhdpi/image_aaab.webp",
             "mipmap-anydpi-v26",
-            "mipmap-anydpi-v26/vector_drawable_aaah.xml",
-            "mipmap-anydpi-v26/vector_drawable_aaag.xml"
+            "mipmap-anydpi-v26/vector_drawable_aaaa.xml",
+            "mipmap-anydpi-v26/vector_drawable_aaab.xml"
         )
     }
 }
@@ -274,6 +274,17 @@ private const val MODEL_FILE = """
             "styleCount": [
               7
             ]
+          },
+          {
+            "stringCount": 0,
+            "intCount": 0,
+            "boolCount": 2,
+            "colorCount": 0,
+            "dimenCount": 0,
+            "idCount": 0,
+            "integerArrayCount": [],
+            "arrayCount": [],
+            "styleCount": []
           }
         ]
       }

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ValueGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ValueGenerationUnitTest.kt
@@ -1,6 +1,7 @@
 package com.android.gradle.replicator.resgen
 
-import com.android.gradle.replicator.resgen.util.ResgenConstants
+import com.android.gradle.replicator.model.internal.filedata.ValuesAndroidResourceProperties
+import com.android.gradle.replicator.model.internal.filedata.ValuesMap
 import com.google.common.truth.Truth
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -9,15 +10,52 @@ import java.io.File
 class ValueGenerationUnitTest: AbstractResourceGenerationTest() {
     @Test
     fun testValueGeneration() {
-        val generator = ValueResourceGenerator(random, ResgenConstants(), uniqueIdGenerator)
+        val generator = ValueResourceGenerator(resourceGenerationParams)
 
         generator.numberOfResourceElements = 5
 
         generator.generateResource(
-                number = 2,
-                outputFolder = testFolder.root,
-                resourceQualifiers = listOf(),
-                resourceExtension = "xml"
+            properties = ValuesAndroidResourceProperties(
+                qualifiers = "",
+                extension = "xml",
+                quantity = 2,
+                valuesMapPerFile = listOf(
+                    ValuesMap(
+                        stringCount = 2,
+                        intCount = 3,
+                        boolCount = 4,
+                        colorCount = 5,
+                        dimenCount = 6,
+                        idCount = 7,
+                        integerArrayCount = mutableListOf(3, 4),
+                        arrayCount = mutableListOf(5, 6),
+                        styleCount = mutableListOf()
+                    ),
+                    ValuesMap(
+                        stringCount = 7,
+                        intCount = 6,
+                        boolCount = 5,
+                        colorCount = 4,
+                        dimenCount = 3,
+                        idCount = 2,
+                        integerArrayCount = mutableListOf(5, 6),
+                        arrayCount = mutableListOf(3, 4),
+                        styleCount = mutableListOf()
+                    ),
+                    ValuesMap(
+                        stringCount = 0,
+                        intCount = 0,
+                        boolCount = 0,
+                        colorCount = 0,
+                        dimenCount = 0,
+                        idCount = 0,
+                        integerArrayCount = mutableListOf(),
+                        arrayCount = mutableListOf(),
+                        styleCount = mutableListOf(4, 5, 6)
+                    )
+                )
+            ),
+            outputFolder = testFolder.root
         )
 
         val generatedValues1 = File(testFolder.root, "values_aaaa.xml").readText()
@@ -26,29 +64,114 @@ class ValueGenerationUnitTest: AbstractResourceGenerationTest() {
         @Language("xml")
         val expectedValues1 = """
             <resources>
-                <string name="cool_delivery_aaaa">nice constable writer wire android</string>
-                <bool name="cookie_etc._the_aaaa">true</bool>
-                <string name="chocolate_vanilla_strawberry_aaab">party</string>
+                <string name="party_aaaa">delivery awesome nice</string>
+                <string name="writer_aaab">android face pie cookie etc. the name max min</string>
+                <integer name="vanilla_aaaa">20</integer>
+                <integer name="party_aaab">23</integer>
+                <integer name="awesome_aaac">26</integer>
+                <bool name="writer_aaaa">true</bool>
+                <bool name="android_face_pie_aaab">false</bool>
+                <bool name="etc._aaac">true</bool>
+                <bool name="name_max_min_aaad">false</bool>
+                <color name="vanilla_aaaa">#0001</color>
+                <color name="party_aaab">#020</color>
+                <color name="awesome_aaac">#04050607</color>
+                <color name="writer_aaad">#08090a</color>
+                <color name="face_aaae">#0b0c</color>
+                <dimen name="etc._aaaa">56px</dimen>
+                <dimen name="min_chocolate_aaab">61pt</dimen>
+                <dimen name="party_aaac">65dp</dimen>
+                <dimen name="nice_constable_aaad">70in</dimen>
+                <dimen name="face_aaae">74px</dimen>
+                <dimen name="the_name_aaaf">79pt</dimen>
+                <item type="id" name="vanilla_aaaa"/>
+                <item type="id" name="pizza_party_cool_aaab"/>
+                <item type="id" name="awesome_aaac"/>
+                <item type="id" name="constable_writer_wire_aaad"/>
+                <item type="id" name="face_aaae"/>
+                <item type="id" name="cookie_etc._the_aaaf"/>
+                <item type="id" name="max_aaag"/>
+                <integer-array name="chocolate_vanilla_strawberry_aaaa">
+                </integer-array>
+                <integer-array name="cool_delivery_aaab">
+                    <item>110</item>
+                    <item>111</item>
+                    <item>112</item>
+                    <item>113</item>
+                </integer-array>
             </resources>""".trimIndent()
 
         @Language("xml")
         val expectedValues2 = """
             <resources>
-                <string name="nice_constable_aaac">wire android face pie cookie etc. the name</string>
-                <item type="id" name="chocolate_vanilla_strawberry_aaaa"/>
-                <bool name="cool_delivery_aaab">false</bool>
-                <integer-array name="constable_writer_wire_aaaa">
-                    <item>52</item>
-                    <item>53</item>
-                    <item>54</item>
-                    <item>55</item>
-                    <item>56</item>
-                    <item>57</item>
-                    <item>58</item>
-                    <item>59</item>
-                    <item>60</item>
+                <string name="face_aaac">cookie etc. the name max min chocolate vanilla strawberry pizza party cool</string>
+                <string name="awesome_aaad">constable writer wire android face pie</string>
+                <string name="etc._aaae">name max min chocolate vanilla strawberry pizza party cool delivery awesome nice constable writer wire</string>
+                <string name="face_aaaf">cookie etc. the name max min chocolate vanilla strawberry pizza party cool</string>
+                <string name="awesome_aaag">constable writer wire android face pie</string>
+                <string name="etc._aaah">name max min chocolate vanilla strawberry pizza party cool delivery awesome nice constable writer wire</string>
+                <string name="face_aaai">cookie etc. the name max min chocolate vanilla strawberry pizza party cool</string>
+                <integer name="awesome_aaad">215</integer>
+                <integer name="writer_aaae">218</integer>
+                <integer name="face_aaaf">221</integer>
+                <integer name="etc._aaag">224</integer>
+                <integer name="max_aaah">227</integer>
+                <integer name="vanilla_aaai">230</integer>
+                <bool name="party_aaae">true</bool>
+                <bool name="delivery_awesome_nice_aaaf">false</bool>
+                <bool name="writer_aaag">true</bool>
+                <bool name="android_face_pie_aaah">false</bool>
+                <bool name="etc._aaai">true</bool>
+                <color name="name_max_min_aaaf">#0d0e</color>
+                <color name="strawberry_pizza_aaag">#0f10</color>
+                <color name="delivery_awesome_nice_aaah">#111213</color>
+                <color name="wire_android_aaai">#141516</color>
+                <dimen name="cookie_etc._the_aaag">267mm</dimen>
+                <dimen name="chocolate_vanilla_strawberry_aaah">273mm</dimen>
+                <dimen name="delivery_awesome_nice_aaai">279mm</dimen>
+                <item type="id" name="android_face_pie_aaah"/>
+                <item type="id" name="etc._aaai"/>
+                <integer-array name="name_max_min_aaac">
+                    <item>292</item>
+                    <item>293</item>
+                    <item>294</item>
+                    <item>295</item>
+                    <item>296</item>
+                    <item>297</item>
+                    <item>298</item>
+                    <item>299</item>
+                    <item>300</item>
+                    <item>301</item>
+                    <item>302</item>
+                    <item>303</item>
+                    <item>304</item>
+                    <item>305</item>
+                    <item>306</item>
+                    <item>307</item>
+                    <item>308</item>
+                    <item>309</item>
                 </integer-array>
-                <item type="id" name="pizza_party_cool_aaab"/>
+                <integer-array name="min_chocolate_aaad">
+                    <item>314</item>
+                    <item>315</item>
+                    <item>316</item>
+                    <item>317</item>
+                    <item>318</item>
+                    <item>319</item>
+                    <item>320</item>
+                    <item>321</item>
+                    <item>322</item>
+                    <item>323</item>
+                    <item>324</item>
+                    <item>325</item>
+                    <item>326</item>
+                    <item>327</item>
+                    <item>328</item>
+                    <item>329</item>
+                    <item>330</item>
+                    <item>331</item>
+                    <item>332</item>
+                </integer-array>
             </resources>""".trimIndent()
 
         Truth.assertThat(generatedValues1).isEqualTo(expectedValues1)

--- a/model/src/main/kotlin/com/android/gradle/replicator/model/internal/filedata/FileProperties.kt
+++ b/model/src/main/kotlin/com/android/gradle/replicator/model/internal/filedata/FileProperties.kt
@@ -25,6 +25,9 @@ val ANDROID_RESOURCE_FOLDER_CONVENTION = mapOf(
  */
 abstract class AbstractAndroidResourceProperties (val qualifiers: String, val extension: String, val quantity: Int) {
         abstract val propertyType: ResourcePropertyType
+
+        val splitQualifiers: List<String>
+            get() = if (qualifiers.isEmpty()) listOf() else qualifiers.split("-")
 }
 
 enum class ResourcePropertyType {

--- a/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
+++ b/plugin/src/main/kotlin/com/android/gradle/replicator/ResourceDataGathering.kt
@@ -85,7 +85,7 @@ fun parseValuesFile(valuesFile: File): ValuesMap {
                     "bool" -> { valuesMap.boolCount++  }
                     "color" -> { valuesMap.colorCount++  }
                     "dimen" -> { valuesMap.dimenCount++  }
-                    "item" -> { if (attributes.getValue("name") == "id") { valuesMap.idCount++ } }
+                    "item" -> { if (attributes.getValue("type") == "id") { valuesMap.idCount++ } }
                     "integer-array" -> {} // Only add on close
                     "array" -> {} // Only add on close
                     "style" -> {} // Only add on close


### PR DESCRIPTION
This commit adds resource generation from the collected metadata to try and match file sizes, line numbers and number of value-type resources.
It also adds memory of resource generation so other resources can reference them.
This also fixes a bug with ID type resources not being collected.