### PR TITLE
Fix task ordering issue

### DIFF
--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/GeneratorDriver.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/GeneratorDriver.kt
@@ -171,6 +171,7 @@ class GeneratorDriver(
             entryName.endsWith(".class")
                     && !entryName.contains("R.class")
                     && !entryName.contains("module-info")
+                    && !entryName.contains("meta-inf", ignoreCase = true)
                     && !entryName.contains('$')
 
     private fun entryNameToClassName(entryName: String): String =

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/SingleClassGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/codegen/SingleClassGenerator.kt
@@ -77,7 +77,7 @@ class SingleClassGenerator(
                     false))
         }
         classGenerator.declareMethod("method", parameters, null, null) {
-            for (blockNumber in params.minNumberOfMethods..random.nextInt(params.maxNumberOfMethodBlocks)) {
+            for (blockNumber in params.minNumberOfMethodBlocks..random.nextInt(params.maxNumberOfMethodBlocks)) {
                 addBlock()
             }
         }

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/codegen/CodeGenerationListenerTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/codegen/CodeGenerationListenerTest.kt
@@ -49,9 +49,11 @@ class CodeGenerationListenerTest {
     @Test
     fun testAnnotationDecorations() {
         val params = ClassGenerationParameters.Builder(
-                maxNumberOfInstanceVars = 1,
-                maxNumberOfMethods = 1,
-                maxNumberOfMethodBlocks = 1
+            maxNumberOfInstanceVars = 1,
+            maxNumberOfMethods = 1,
+            // Having min higher than max means no blocks are generated
+            minNumberOfMethodBlocks = 1,
+            maxNumberOfMethodBlocks = 0
         ).build()
 
         val listener = object : CodeGenerationListener {

--- a/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/CodegenPlugin.kt
+++ b/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/CodegenPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.ArtifactAttributes
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import kotlin.random.Random
 
 @Suppress("UnstableApiUsage")
@@ -186,5 +187,6 @@ class CodegenPlugin: AbstractCodeGenPlugin() {
         // generate the code before we start compiling it.
         // hack, use variant API.
         project.tasks.findByName("preBuild")!!.dependsOn(generateCodeTask)
+        project.tasks.withType(KotlinCompile::class.java).configureEach { it.dependsOn(generateCodeTask) }
     }
 }

--- a/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/JavaLibraryCodegenPlugin.kt
+++ b/code/plugin/src/main/kotlin/com/android/gradle/replicator/codegen/plugin/JavaLibraryCodegenPlugin.kt
@@ -21,6 +21,8 @@ import org.gradle.api.artifacts.ArtifactView
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import kotlin.random.Random
 
 @Suppress("UnstableApiUsage")
@@ -34,8 +36,6 @@ class JavaLibraryCodegenPlugin: AbstractCodeGenPlugin() {
             while (current.parent != null) current = current.parent!!
             current.name
         }
-
-        val hasKotlinSources = project.pluginManager.hasPlugin("org.jetbrains.kotlin.jvm")
 
         val generateTask = project.tasks.register(
                 "generateCodegenParams",
@@ -99,6 +99,11 @@ class JavaLibraryCodegenPlugin: AbstractCodeGenPlugin() {
         }
 
         // generate the code before we start compiling it.
-        project.tasks.findByName(if (hasKotlinSources) "compileKotlin" else "compileJava")!!.dependsOn(generateCodeTask)
+        project.tasks.withType(JavaCompile::class.java).configureEach {
+            it.dependsOn(generateCodeTask)
+        }
+        project.tasks.withType(KotlinCompile::class.java).configureEach {
+            it.dependsOn(generateCodeTask)
+        }
     }
 }


### PR DESCRIPTION
Make sure sources are generated before Java/Kotlin compilation starts. Forcing "preBuild" task to depend on source generation works for AGP-created tasks. This change forces Kotlin/KAPT tasks to also depend on it.

In this change there are also the following fixes:
- for non-Android projects, make sure kapt also depends on source generation
- fix number of generated blocks in the method
- ignore multi-release jar classes when finding available types