### PR TITLE
Reuse names across resources qualifiers

### DIFF
--- a/code/codegen/build.gradle.kts
+++ b/code/codegen/build.gradle.kts
@@ -53,7 +53,8 @@ dependencies {
     implementation("org.ow2.asm:asm:9.4")
     implementation("org.ow2.asm:asm-tree:9.4")
 
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+    implementation("com.google.code.gson:gson:2.10")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.google.guava:guava:30.0-jre")

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/DrawableResourceGenerator.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/DrawableResourceGenerator.kt
@@ -25,13 +25,9 @@ import com.android.gradle.replicator.resgen.util.VectorDrawableGenerator
 import com.android.gradle.replicator.resgen.util.copyResourceFile
 import com.android.gradle.replicator.resgen.util.getFileType
 import com.android.gradle.replicator.resgen.util.getResourceClosestToSize
-import com.google.common.annotations.VisibleForTesting
 import java.io.File
 
 class DrawableResourceGenerator (params: ResourceGenerationParams): ResourceGenerator(params) {
-
-    @set:VisibleForTesting
-    var numberOfResourceElements: Long?= null
 
     private val supportedFileTypes = listOf(
             FileTypes.PNG,

--- a/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/resourceModel/ResourceModel.kt
+++ b/code/codegen/src/main/kotlin/com/android/gradle/replicator/resgen/resourceModel/ResourceModel.kt
@@ -11,3 +11,13 @@ data class ResourceData (
 class ResourceModel {
     val resourceList: MutableList<ResourceData> = mutableListOf()
 }
+
+enum class ResourceDataType(val typeName: String) {
+    STRING("values_string"),
+    BOOL("values_bool"),
+    INT("values_int"),
+    COLOR("values_color"),
+    DIMEN("values_dimen"),
+    INT_ARRAY("values_int_array"),
+    ID("values_id"),
+}

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/DrawableGenerationUnitTest.kt
@@ -10,7 +10,6 @@ class DrawableGenerationUnitTest: AbstractResourceGenerationTest() {
     @Test
     fun testDrawableGeneration() {
         val generator = DrawableResourceGenerator(resourceGenerationParams)
-        generator.numberOfResourceElements = 3
 
         val pngFolder = testFolder.newFolder("png")
         val pngQualifiedFolder = testFolder.newFolder("png-xxxhdpi")

--- a/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ValueGenerationUnitTest.kt
+++ b/code/codegen/src/test/kotlin/com/android/gradle/replicator/resgen/ValueGenerationUnitTest.kt
@@ -11,9 +11,6 @@ class ValueGenerationUnitTest: AbstractResourceGenerationTest() {
     @Test
     fun testValueGeneration() {
         val generator = ValueResourceGenerator(resourceGenerationParams)
-
-        generator.numberOfResourceElements = 5
-
         generator.generateResource(
             properties = ValuesAndroidResourceProperties(
                 qualifiers = "",
@@ -176,5 +173,44 @@ class ValueGenerationUnitTest: AbstractResourceGenerationTest() {
 
         Truth.assertThat(generatedValues1).isEqualTo(expectedValues1)
         Truth.assertThat(generatedValues2).isEqualTo(expectedValues2)
+    }
+
+    @Test
+    fun testQualifiersReuseNames() {
+        val generator = ValueResourceGenerator(resourceGenerationParams)
+        generator.generateResource(
+            properties = ValuesAndroidResourceProperties(
+                qualifiers = "",
+                extension = "xml",
+                quantity = 1,
+                valuesMapPerFile = listOf(
+                    ValuesMap(
+                        stringCount = 2,
+                        colorCount = 2,
+                    ),
+                )
+            ),
+            outputFolder = testFolder.newFolder("no-qualifiers")
+        )
+        val enUK = "en-UK"
+        generator.generateResource(
+            properties = ValuesAndroidResourceProperties(
+                qualifiers = enUK,
+                extension = "xml",
+                quantity = 1,
+                valuesMapPerFile = listOf(
+                    ValuesMap(
+                        stringCount = 2,
+                        colorCount = 2,
+                    ),
+                )
+            ),
+            outputFolder = testFolder.newFolder("qualifiers")
+        )
+
+        val noQualifiersNames = resourceGenerationParams.resourceModel.resourceList.filter { it.qualifiers.isEmpty() }.map { it.name }
+        val withQualifiersNames = resourceGenerationParams.resourceModel.resourceList.filter { it.qualifiers == listOf(enUK) }.map { it.name }
+
+        Truth.assertThat(noQualifiersNames).containsExactlyElementsIn(withQualifiersNames)
     }
 }

--- a/code/plugin/build.gradle.kts
+++ b/code/plugin/build.gradle.kts
@@ -26,7 +26,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+    implementation("com.google.code.gson:gson:2.10")
     implementation(project(":code:codegen"))
 }
 

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("com.squareup.tools.build:maven-archeologist:0.0.3.1")
 
-    implementation("com.google.code.gson:gson:2.8.5")
+    implementation("com.google.code.gson:gson:2.10")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    implementation("com.google.code.gson:gson:2.8.5")
+    implementation("com.google.code.gson:gson:2.10")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")


### PR DESCRIPTION
In order to avoid generating more than 64K resources IDs, reuse names for the same resources types with different qualifiers.

Also, update KGP and Kotlin std lib versions in the build.